### PR TITLE
Nonblocking finish

### DIFF
--- a/inc/hclib.h
+++ b/inc/hclib.h
@@ -150,6 +150,15 @@ void hclib_forasync(void *forasync_fct, void *argv, hclib_ddf_t **ddf_list,
         struct _phased_t *phased_clause, void *accumed_placeholder, int dim,
         loop_domain_t *domain, forasync_mode_t mode);
 
+/*
+ * Semantically equivalent to hclib_forasync, but returns a DDF that is
+ * triggered when all tasks belonging to this forasync have finished.
+ */
+hclib_ddf_t *hclib_forasync_future(void *forasync_fct, void *argv,
+        hclib_ddf_t **ddf_list, struct _phased_t *phased_clause,
+        void *accumed_placeholder, int dim, loop_domain_t *domain,
+        forasync_mode_t mode);
+
 /**
  * @brief starts a new finish scope
  */
@@ -159,6 +168,12 @@ void hclib_start_finish();
  * @brief ends the current finish scope
  */
 void hclib_end_finish();
+
+/*
+ * Get a DDF that is triggered when all tasks inside this finish scope have
+ * finished, but return immediately.
+ */
+hclib_ddf_t *hclib_end_finish_nonblocking();
 
 /**
  * @}

--- a/inc/hclib_cpp.h
+++ b/inc/hclib_cpp.h
@@ -22,6 +22,7 @@ void launch(int *argc, char **argv, T lambda) {
 
 void start_finish();
 void end_finish();
+ddf_t *end_finish_nonblocking();
 
 ddf_t *ddf_create();
 void ddf_free(ddf_t *ddf);

--- a/inc/hclib_cpp.h
+++ b/inc/hclib_cpp.h
@@ -20,10 +20,6 @@ void launch(int *argc, char **argv, T lambda) {
     hclib_launch(argc, argv, (generic_framePtr)spawn, user_task);
 }
 
-void start_finish();
-void end_finish();
-ddf_t *end_finish_nonblocking();
-
 ddf_t *ddf_create();
 void ddf_free(ddf_t *ddf);
 void ddf_put(ddf_t *ddf, void *datum);

--- a/inc/hcpp-async.h
+++ b/inc/hcpp-async.h
@@ -191,6 +191,12 @@ inline void finish(std::function<void()> lambda) {
     hclib_end_finish();
 }
 
+inline hclib_ddf_t *nonblocking_finish(std::function<void()> lambda) {
+    hclib_start_finish();
+    lambda();
+    return hclib_end_finish_nonblocking();
+}
+
 }
 
 #endif /* HCPP_ASYNC_H_ */

--- a/inc/hcpp-forasync.h
+++ b/inc/hcpp-forasync.h
@@ -368,18 +368,45 @@ inline void forasync3D_internal(const _loop_domain_t loop[3], T lambda, int mode
 }
 
 template <typename T>
-inline void forasync1D(_loop_domain_t* loop, T lambda, int mode=FORASYNC_MODE_RECURSIVE) {
-		forasync1D_internal<T>(loop, lambda, mode);
+inline void forasync1D(_loop_domain_t* loop, T lambda,
+        int mode=FORASYNC_MODE_RECURSIVE) {
+    forasync1D_internal<T>(loop, lambda, mode);
 }
 
 template <typename T>
-inline void forasync2D(_loop_domain_t* loop, T lambda, int mode=FORASYNC_MODE_RECURSIVE) {
-		forasync2D_internal<T>(loop, lambda, mode);
+inline void forasync2D(_loop_domain_t* loop, T lambda,
+        int mode=FORASYNC_MODE_RECURSIVE) {
+    forasync2D_internal<T>(loop, lambda, mode);
 }
 
 template <typename T>
-inline void forasync3D(_loop_domain_t* loop, T lambda, int mode=FORASYNC_MODE_RECURSIVE) {
-		forasync3D_internal<T>(loop, lambda, mode);
+inline void forasync3D(_loop_domain_t* loop, T lambda,
+        int mode=FORASYNC_MODE_RECURSIVE) {
+    forasync3D_internal<T>(loop, lambda, mode);
+}
+
+template <typename T>
+inline hclib_ddf_t *forasync1D_future(_loop_domain_t* loop, T lambda,
+        int mode=FORASYNC_MODE_RECURSIVE) {
+    hclib_start_finish();
+    forasync1D_internal<T>(loop, lambda, mode);
+    return hclib_end_finish_nonblocking();
+}
+
+template <typename T>
+inline hclib_ddf_t *forasync2D_future(_loop_domain_t* loop, T lambda,
+        int mode=FORASYNC_MODE_RECURSIVE) {
+    hclib_start_finish();
+    forasync2D_internal<T>(loop, lambda, mode);
+    return hclib_end_finish_nonblocking();
+}
+
+template <typename T>
+inline hclib_ddf_t *forasync3D_future(_loop_domain_t* loop, T lambda,
+        int mode=FORASYNC_MODE_RECURSIVE) {
+    hclib_start_finish();
+    forasync3D_internal<T>(loop, lambda, mode);
+    return hclib_end_finish_nonblocking();
 }
 
 }

--- a/src/hclib.c
+++ b/src/hclib.c
@@ -452,6 +452,18 @@ void hclib_forasync(void* forasync_fct, void * argv, hclib_ddf_t** ddf_list,
     forasync_internal(forasync_fct, argv, accumed, dim, domain, mode);
 }
 
+hclib_ddf_t *hclib_forasync_future(void* forasync_fct, void * argv,
+        hclib_ddf_t** ddf_list, struct _phased_t * phased_clause,
+        void *accumed /* struct _accumed_t * accumed */ , int dim,
+        loop_domain_t * domain, forasync_mode_t mode) {
+
+    hclib_start_finish();
+    hclib_forasync(forasync_fct, argv, ddf_list, phased_clause, accumed, dim,
+            domain, mode);
+    return hclib_end_finish_nonblocking();
+}
+
+
 /*** END FORASYNC IMPLEMENTATION ***/
 
 #ifdef __cplusplus

--- a/src/hclib_cpp.cpp
+++ b/src/hclib_cpp.cpp
@@ -8,6 +8,10 @@ void hclib::end_finish() {
     hclib_end_finish();
 }
 
+hclib::ddf_t *hclib::end_finish_nonblocking() {
+    return hclib_end_finish_nonblocking();
+}
+
 hclib::ddf_t *hclib::ddf_create() {
     return hclib_ddf_create();
 }

--- a/src/hclib_cpp.cpp
+++ b/src/hclib_cpp.cpp
@@ -1,17 +1,5 @@
 #include "hclib_cpp.h"
 
-void hclib::start_finish() {
-    hclib_start_finish();
-}
-
-void hclib::end_finish() {
-    hclib_end_finish();
-}
-
-hclib::ddf_t *hclib::end_finish_nonblocking() {
-    return hclib_end_finish_nonblocking();
-}
-
 hclib::ddf_t *hclib::ddf_create() {
     return hclib_ddf_create();
 }

--- a/test/c/.gitignore
+++ b/test/c/.gitignore
@@ -6,6 +6,8 @@ ddf/asyncAwait0Null
 ddf/asyncAwait1
 ddf/future0
 ddf/future1
+ddf/future2
+ddf/future3
 finish0
 finish1
 finish2

--- a/test/c/Makefile
+++ b/test/c/Makefile
@@ -2,7 +2,8 @@ include $(HCPP_ROOT)/include/hcpp.mak
 
 TARGETS=async0 async1 finish0 finish1 finish2  forasync1DCh  forasync1DRec \
 		forasync2DCh  forasync2DRec  forasync3DCh  forasync3DRec \
-		ddf/asyncAwait0 ddf/asyncAwait0Null ddf/asyncAwait1 ddf/future0 ddf/future1
+		ddf/asyncAwait0 ddf/asyncAwait0Null ddf/asyncAwait1 ddf/future0 \
+		ddf/future1 ddf/future2 ddf/future3
 
 FLAGS=-g
 

--- a/test/c/ddf/future2.c
+++ b/test/c/ddf/future2.c
@@ -39,7 +39,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "hclib.h"
 
-#define H1 1024
+#define H1 256
 #define T1 33
 
 //user written code

--- a/test/c/ddf/future2.c
+++ b/test/c/ddf/future2.c
@@ -1,0 +1,96 @@
+/* Copyright (c) 2013, Rice University
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+1.  Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+2.  Redistributions in binary form must reproduce the above
+     copyright notice, this list of conditions and the following
+     disclaimer in the documentation and/or other materials provided
+     with the distribution.
+3.  Neither the name of Rice University
+     nor the names of its contributors may be used to endorse or
+     promote products derived from this software without specific
+     prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+ */
+
+/**
+ * DESC: Fork a bunch of asyncs in a top-level loop
+ */
+#include <stdlib.h>
+#include <stdio.h>
+#include <assert.h>
+#include <unistd.h>
+
+#include "hclib.h"
+
+#define H1 1024
+#define T1 33
+
+//user written code
+void forasync_fct1(void *argv, int idx) {
+    int *ran = (int *)argv;
+
+    sleep(1);
+
+    assert(ran[idx] == -1);
+    ran[idx] = idx;
+    printf("finished %d / %d\n", idx, H1);
+}
+
+void init_ran(int *ran, int size) {
+    while (size > 0) {
+        ran[size-1] = -1;
+        size--;
+    }
+}
+
+void entrypoint(void *arg) {
+    int *ran = (int *)arg;
+    int i = 0;
+    // This is ok to have these on stack because this
+    // code is alive until the end of the program.
+
+    init_ran(ran, H1);
+    loop_domain_t loop = {0, H1, 1, T1};
+
+    hclib_start_finish();
+    hclib_forasync(forasync_fct1, (void*)ran, NULL, NULL, NULL, 1, &loop,
+            FORASYNC_MODE_FLAT);
+    hclib_ddf_t *event = hclib_end_finish_nonblocking();
+
+    hclib_ddf_wait(event);
+    printf("Call Finalize\n");
+}
+
+int main (int argc, char ** argv) {
+    printf("Call Init\n");
+    int *ran=(int *)malloc(H1*sizeof(int));
+    assert(ran);
+
+    hclib_launch(&argc, argv, entrypoint, ran);
+
+    printf("Check results: ");
+    int i = 0;
+    while(i < H1) {
+        assert(ran[i] == i);
+        i++;
+    }
+    printf("OK\n");
+    return 0;
+}

--- a/test/c/ddf/future2.c
+++ b/test/c/ddf/future2.c
@@ -1,4 +1,4 @@
-/* Copyright (c) 2013, Rice University
+/* Copyright (c) 2015, Rice University
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are

--- a/test/c/ddf/future3.c
+++ b/test/c/ddf/future3.c
@@ -39,7 +39,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "hclib.h"
 
-#define H1 1024
+#define H1 256
 #define T1 33
 
 //user written code

--- a/test/c/ddf/future3.c
+++ b/test/c/ddf/future3.c
@@ -1,0 +1,94 @@
+/* Copyright (c) 2013, Rice University
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+1.  Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+2.  Redistributions in binary form must reproduce the above
+     copyright notice, this list of conditions and the following
+     disclaimer in the documentation and/or other materials provided
+     with the distribution.
+3.  Neither the name of Rice University
+     nor the names of its contributors may be used to endorse or
+     promote products derived from this software without specific
+     prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+ */
+
+/**
+ * DESC: Fork a bunch of asyncs in a top-level loop
+ */
+#include <stdlib.h>
+#include <stdio.h>
+#include <assert.h>
+#include <unistd.h>
+
+#include "hclib.h"
+
+#define H1 1024
+#define T1 33
+
+//user written code
+void forasync_fct1(void *argv, int idx) {
+    int *ran = (int *)argv;
+
+    sleep(1);
+
+    assert(ran[idx] == -1);
+    ran[idx] = idx;
+    printf("finished %d / %d\n", idx, H1);
+}
+
+void init_ran(int *ran, int size) {
+    while (size > 0) {
+        ran[size-1] = -1;
+        size--;
+    }
+}
+
+void entrypoint(void *arg) {
+    int *ran = (int *)arg;
+    int i = 0;
+    // This is ok to have these on stack because this
+    // code is alive until the end of the program.
+
+    init_ran(ran, H1);
+    loop_domain_t loop = {0, H1, 1, T1};
+
+    hclib_ddf_t *event = hclib_forasync_future(forasync_fct1, (void*)ran, NULL,
+            NULL, NULL, 1, &loop, FORASYNC_MODE_FLAT);
+
+    hclib_ddf_wait(event);
+    printf("Call Finalize\n");
+}
+
+int main (int argc, char ** argv) {
+    printf("Call Init\n");
+    int *ran=(int *)malloc(H1*sizeof(int));
+    assert(ran);
+
+    hclib_launch(&argc, argv, entrypoint, ran);
+
+    printf("Check results: ");
+    int i = 0;
+    while(i < H1) {
+        assert(ran[i] == i);
+        i++;
+    }
+    printf("OK\n");
+    return 0;
+}

--- a/test/c/ddf/future3.c
+++ b/test/c/ddf/future3.c
@@ -1,4 +1,4 @@
-/* Copyright (c) 2013, Rice University
+/* Copyright (c) 2015, Rice University
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are

--- a/test/cpp/.gitignore
+++ b/test/cpp/.gitignore
@@ -6,6 +6,8 @@ ddf/asyncAwait0Null
 ddf/asyncAwait1
 ddf/future0
 ddf/future1
+ddf/future2
+ddf/future3
 finish0
 finish1
 finish2

--- a/test/cpp/Makefile
+++ b/test/cpp/Makefile
@@ -2,7 +2,8 @@ include $(HCPP_ROOT)/include/hcpp.mak
 
 TARGETS=async0 async1 finish0 finish1 finish2  forasync1DCh  forasync1DRec \
 		forasync2DCh  forasync2DRec  forasync3DCh  forasync3DRec \
-		ddf/asyncAwait0 ddf/asyncAwait0Null ddf/asyncAwait1 ddf/future0 ddf/future1
+		ddf/asyncAwait0 ddf/asyncAwait0Null ddf/asyncAwait1 ddf/future0 \
+		ddf/future1 ddf/future2 ddf/future3
 
 FLAGS=-g -std=c++11
 

--- a/test/cpp/ddf/future0.cpp
+++ b/test/cpp/ddf/future0.cpp
@@ -28,7 +28,7 @@ int main(int argc, char ** argv) {
                     assert(ddf_list);
                     ddf_list[0] = prev;
                     ddf_list[1] = NULL;
-                    prev = hclib::asyncFuture([=]() {
+                    prev = hclib::asyncFutureAwait(ddf_list, [=]() {
                             printf("Running async with count = %d\n", *count);
                             *count = *count + 1;
                         });

--- a/test/cpp/ddf/future2.cpp
+++ b/test/cpp/ddf/future2.cpp
@@ -39,7 +39,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "hclib_cpp.h"
 
-#define H1 1024
+#define H1 512
 #define T1 33
 
 void init_ran(int *ran, int size) {

--- a/test/cpp/ddf/future2.cpp
+++ b/test/cpp/ddf/future2.cpp
@@ -1,0 +1,93 @@
+/* Copyright (c) 2013, Rice University
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+1.  Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+2.  Redistributions in binary form must reproduce the above
+     copyright notice, this list of conditions and the following
+     disclaimer in the documentation and/or other materials provided
+     with the distribution.
+3.  Neither the name of Rice University
+     nor the names of its contributors may be used to endorse or
+     promote products derived from this software without specific
+     prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+ */
+
+/**
+ * DESC: Fork a bunch of asyncs in a top-level loop
+ */
+#include <stdlib.h>
+#include <stdio.h>
+#include <assert.h>
+#include <unistd.h>
+
+#include "hclib_cpp.h"
+
+#define H1 1024
+#define T1 33
+
+//user written code
+void forasync_fct1(void *argv, int idx) {
+    int *ran = (int *)argv;
+
+    sleep(1);
+
+    assert(ran[idx] == -1);
+    ran[idx] = idx;
+    printf("finished %d / %d\n", idx, H1);
+}
+
+void init_ran(int *ran, int size) {
+    while (size > 0) {
+        ran[size-1] = -1;
+        size--;
+    }
+}
+
+int main (int argc, char ** argv) {
+    printf("Call Init\n");
+    int *ran=(int *)malloc(H1*sizeof(int));
+    assert(ran);
+
+    hclib::launch(&argc, argv, [=]() {
+            int i = 0;
+            // This is ok to have these on stack because this
+            // code is alive until the end of the program.
+
+            init_ran(ran, H1);
+            loop_domain_t loop = {0, H1, 1, T1};
+
+            hclib::finish([=]() {
+                hclib_forasync(forasync_fct1, (void*)ran, NULL, NULL, NULL, 1, &loop,
+                        FORASYNC_MODE_FLAT);
+            hclib_ddf_t *event = hclib_end_finish_nonblocking();
+
+            hclib_ddf_wait(event);
+            printf("Call Finalize\n");
+        });
+
+    printf("Check results: ");
+    int i = 0;
+    while(i < H1) {
+        assert(ran[i] == i);
+        i++;
+    }
+    printf("OK\n");
+    return 0;
+}

--- a/test/cpp/ddf/future2.cpp
+++ b/test/cpp/ddf/future2.cpp
@@ -39,7 +39,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "hclib_cpp.h"
 
-#define H1 512
+#define H1 256
 #define T1 33
 
 void init_ran(int *ran, int size) {

--- a/test/cpp/ddf/future2.cpp
+++ b/test/cpp/ddf/future2.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2013, Rice University
+/* Copyright (c) 2015, Rice University
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are

--- a/test/cpp/ddf/future3.cpp
+++ b/test/cpp/ddf/future3.cpp
@@ -39,7 +39,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "hclib_cpp.h"
 
-#define H1 512
+#define H1 256
 #define T1 33
 
 //user written code

--- a/test/cpp/ddf/future3.cpp
+++ b/test/cpp/ddf/future3.cpp
@@ -39,7 +39,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "hclib_cpp.h"
 
-#define H1 1024
+#define H1 512
 #define T1 33
 
 //user written code

--- a/test/cpp/ddf/future3.cpp
+++ b/test/cpp/ddf/future3.cpp
@@ -1,0 +1,94 @@
+/* Copyright (c) 2013, Rice University
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+1.  Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+2.  Redistributions in binary form must reproduce the above
+     copyright notice, this list of conditions and the following
+     disclaimer in the documentation and/or other materials provided
+     with the distribution.
+3.  Neither the name of Rice University
+     nor the names of its contributors may be used to endorse or
+     promote products derived from this software without specific
+     prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+ */
+
+/**
+ * DESC: Fork a bunch of asyncs in a top-level loop
+ */
+#include <stdlib.h>
+#include <stdio.h>
+#include <assert.h>
+#include <unistd.h>
+
+#include "hclib.h"
+
+#define H1 1024
+#define T1 33
+
+//user written code
+void forasync_fct1(void *argv, int idx) {
+    int *ran = (int *)argv;
+
+    sleep(1);
+
+    assert(ran[idx] == -1);
+    ran[idx] = idx;
+    printf("finished %d / %d\n", idx, H1);
+}
+
+void init_ran(int *ran, int size) {
+    while (size > 0) {
+        ran[size-1] = -1;
+        size--;
+    }
+}
+
+void entrypoint(void *arg) {
+    int *ran = (int *)arg;
+    int i = 0;
+    // This is ok to have these on stack because this
+    // code is alive until the end of the program.
+
+    init_ran(ran, H1);
+    loop_domain_t loop = {0, H1, 1, T1};
+
+    hclib_ddf_t *event = hclib_forasync_future(forasync_fct1, (void*)ran, NULL,
+            NULL, NULL, 1, &loop, FORASYNC_MODE_FLAT);
+
+    hclib_ddf_wait(event);
+    printf("Call Finalize\n");
+}
+
+int main (int argc, char ** argv) {
+    printf("Call Init\n");
+    int *ran=(int *)malloc(H1*sizeof(int));
+    assert(ran);
+
+    hclib_launch(&argc, argv, entrypoint, ran);
+
+    printf("Check results: ");
+    int i = 0;
+    while(i < H1) {
+        assert(ran[i] == i);
+        i++;
+    }
+    printf("OK\n");
+    return 0;
+}

--- a/test/cpp/ddf/future3.cpp
+++ b/test/cpp/ddf/future3.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2013, Rice University
+/* Copyright (c) 2015, Rice University
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are


### PR DESCRIPTION
This review adds the concept of a non-blocking finish and uses it to implement a future-like forasync.

A non-blocking finish can be used to group tasks within a finish scope together. Rather than blocking on an end-finish, a non-blocking finish returns a promise that can be used to synchronize on the completion of all tasks in the finish scope. This allows the chaining of finish scopes and individual asyncs (or other asynchronous constructs in HCLib, such as asynchronous copies to a GPU).

This review also implements an example use of a nonblocking finish, a future-like forasync that returns a single event which can be used to synchronize on all tasks that are part of the same forasync.

Examples/tests are also added for both nonblocking finishes and future-forasync.
