### PR TITLE
Minimize context swaps

### DIFF
--- a/src/hclib-hpt.c
+++ b/src/hclib-hpt.c
@@ -115,8 +115,8 @@ hclib_task_t *hpt_pop_task(hclib_worker_state *ws) {
     while (current != NULL) {
 #ifdef VERBOSE
         printf("hpt_pop_task: worker %d looking to pop from deque %p in "
-                "place %p at level %d\n", ws->id, current, current->pl,
-                current->pl->level);
+               "place %p at level %d\n", ws->id, current, current->pl,
+               current->pl->level);
 #endif
         hclib_task_t *buff = deque_pop(&current->deque);
         if (buff) {

--- a/src/hclib-runtime.c
+++ b/src/hclib-runtime.c
@@ -159,10 +159,10 @@ void hclib_global_init() {
                                   &hclib_context->workers, &hclib_context->nworkers);
 
 #ifdef HC_COMM_WORKER
-    assert(hclib_context->nworkers > COMMUNICATION_WORKER_ID);
+    HASSERT(hclib_context->nworkers > COMMUNICATION_WORKER_ID);
 #endif
 #ifdef HC_CUDA
-    assert(hclib_context->nworkers > GPU_WORKER_ID);
+    HASSERT(hclib_context->nworkers > GPU_WORKER_ID);
 #endif
 
     for (int i = 0; i < hclib_context->nworkers; i++) {

--- a/src/hclib-runtime.c
+++ b/src/hclib-runtime.c
@@ -91,17 +91,19 @@ int total_push_outd;
 int *total_push_ind;
 int *total_steals;
 
-inline void increment_async_counter(int wid) {
+static inline void increment_async_counter(int wid) {
     total_push_ind[wid]++;
 }
 
-inline void increment_steals_counter(int wid) {
+static inline void increment_steals_counter(int wid) {
     total_steals[wid]++;
 }
 
-inline void increment_asyncComm_counter() {
+#ifdef HC_COMM_WORKER_STATS
+static inline void increment_asyncComm_counter() {
     total_push_outd++;
 }
+#endif
 
 void set_current_worker(int wid) {
     if (pthread_setspecific(ws_key, hclib_context->workers[wid]) != 0) {
@@ -429,7 +431,7 @@ static inline void rt_schedule_async(hclib_task_t *async_task, int comm_task,
  * registered on each, and it is only placed in a work deque once all promises have
  * been satisfied.
  */
-inline int is_eligible_to_schedule(hclib_task_t *async_task) {
+static inline int is_eligible_to_schedule(hclib_task_t *async_task) {
 #ifdef VERBOSE
     fprintf(stderr, "is_eligible_to_schedule: async_task=%p future_list=%p\n",
             async_task, async_task->future_list);
@@ -1173,7 +1175,7 @@ void hclib_gather_comm_worker_stats(int *push_outd, int *push_ind,
     *steal_ind = steals;
 }
 
-double mysecond() {
+static double mysecond() {
     struct timeval tv;
     gettimeofday(&tv, 0);
     return tv.tv_sec + ((double) tv.tv_usec / 1000000);

--- a/src/hclib.c
+++ b/src/hclib.c
@@ -14,7 +14,7 @@ extern "C" {
 
 void hclib_async(generic_frame_ptr fp, void *arg, hclib_future_t **future_list,
                  struct _phased_t *phased_clause, place_t *place, int property) {
- //   HASSERT(property == 0);
+//   HASSERT(property == 0);
     HASSERT(phased_clause == NULL);
 
     if (future_list) {
@@ -41,16 +41,16 @@ void hclib_async(generic_frame_ptr fp, void *arg, hclib_future_t **future_list,
         if (place) {
             spawn_at_hpt(place, task);
         } else {
-	    if(property == 0) spawn(task);
-	    /* 
-	     * ^^^^^ TODO: Presently this path executed only for HabaneroOpenSHMEM++ ^^^^^^
-	     * This else part is executed only if hclib::launch() is called from 
-	     * HabaneroUPC++ or HabaneroOpenSHMEM++. This task is essentially the main()
-	     * function which has the finish_spmd(). This finish_spmd is only allowed
-             * to execute on a comm_async and not on a regular async. Regular async
-	     * would allow this finish_spmd to be executed by computation worker.
-	     */
-	    else spawn_comm_task(task);	
+            if(property == 0) spawn(task);
+            /*
+             * ^^^^^ TODO: Presently this path executed only for HabaneroOpenSHMEM++ ^^^^^^
+             * This else part is executed only if hclib::launch() is called from
+             * HabaneroUPC++ or HabaneroOpenSHMEM++. This task is essentially the main()
+             * function which has the finish_spmd(). This finish_spmd is only allowed
+                 * to execute on a comm_async and not on a regular async. Regular async
+             * would allow this finish_spmd to be executed by computation worker.
+             */
+            else spawn_comm_task(task);
         }
     }
 }
@@ -68,8 +68,8 @@ static void future_caller(void *in) {
 }
 
 hclib_future_t *hclib_async_future(futureFct_t fp, void *arg,
-                                    hclib_future_t **future_list, struct _phased_t *phased_clause,
-                                    place_t *place, int property) {
+                                   hclib_future_t **future_list, struct _phased_t *phased_clause,
+                                   place_t *place, int property) {
     future_args_wrapper *wrapper = malloc(sizeof(future_args_wrapper));
     hclib_promise_init(&wrapper->event);
     wrapper->fp = fp;

--- a/test/deadlock/Makefile
+++ b/test/deadlock/Makefile
@@ -2,13 +2,13 @@ TARGET := deadlock
 
 $(TARGET): $(TARGET).c
 	@ [ -d "${HCLIB_ROOT}" ] || (echo Need to set HCLIB_ROOT; exit 1)
-	gcc $^ -o$@ -pthread -std=gnu99 -I${HCLIB_ROOT}/include ${HCLIB_ROOT}/lib/libhclib.a -lxml2 -L${LIBXML2_LIBS} -lcudart
+	gcc $^ -o$@ -pthread -std=gnu99 -I${HCLIB_ROOT}/include ${HCLIB_ROOT}/lib/libhclib.a -lxml2 -L${LIBXML2_LIBS}
 
 NPROC ?= 4
 
 .PHONY: run
 run: $(TARGET)
-	./$(TARGET) -nproc $(NPROC)
+	HCLIB_WORKERS=$(NPROC) ./$(TARGET)
 
 clean:
 	rm -f $(TARGET)

--- a/test/deadlock/deadlock.c
+++ b/test/deadlock/deadlock.c
@@ -1,8 +1,9 @@
 #include <stdlib.h>
 #include <stdio.h>
-#include <hclib.h>
 #include <unistd.h>
 #include <stdbool.h>
+
+#include "hclib.h"
 
 #define FINISH GEN_FINISH_SCOPE(MACRO_CONCAT(_hcGenVar_, __COUNTER__))
 #define GEN_FINISH_SCOPE(V) for (int V=(hclib_start_finish(), 1); V; hclib_end_finish(), --V)
@@ -60,7 +61,7 @@ void taskMain(void *args) {
     future_list = (hclib_future_t **)malloc(1 * sizeof(hclib_future_t *));
     promise = hclib_promise_create();
     promise_list[0] = promise;
-    future_list[0] = hclib_get_future(promise);
+    future_list[0] = hclib_get_future_for_promise(promise);
 
     hclib_async(&taskA, NULL, NO_FUTURE, NO_PHASER, ANY_PLACE, NO_PROP);
     hclib_async(&taskC, NULL, NO_FUTURE, NO_PHASER, ANY_PLACE, NO_PROP);
@@ -68,6 +69,6 @@ void taskMain(void *args) {
 }
 
 int main(int argc, char ** argv) {
-    hclib_launch(&argc, argv, taskMain, NULL);
+    hclib_launch(taskMain, NULL);
     printf("Done\n");
 }

--- a/test/fib/Makefile
+++ b/test/fib/Makefile
@@ -1,0 +1,32 @@
+TARGET := fib
+
+$(TARGET): $(TARGET).c
+	@ [ -d "${HCLIB_ROOT}" ] || (echo Need to set HCLIB_ROOT; exit 1)
+	gcc $^ -o$@ -pthread -std=gnu11 -I. -I${HCLIB_ROOT}/include ${HCLIB_ROOT}/lib/libhclib.a -lxml2 -L${LIBXML2_LIBS}
+
+WORKLOAD_ARGS ?= 5
+
+NPROC ?= 4
+
+.PHONY: run
+run: $(TARGET)
+	$(SETUP_ENV) HCLIB_WORKERS=$(NPROC) ./$(TARGET) $(WORKLOAD_ARGS)
+
+.PHONY: hoard
+hoard: SETUP_ENV=LD_PRELOAD="/opt/local/Hoard/lib/libhoard.so"
+hoard: run
+
+.PHONY: tbbmalloc
+tbbmalloc: SETUP_ENV=LD_PRELOAD="/usr/lib/libtbbmalloc_proxy.so"
+tbbmalloc: run
+
+.PHONY: tcmalloc
+tcmalloc: SETUP_ENV=LD_PRELOAD="/usr/lib/libtcmalloc.so.4"
+tcmalloc: run
+
+.PHONY: jemalloc
+jemalloc: SETUP_ENV=LD_PRELOAD="/usr/lib/x86_64-linux-gnu/libjemalloc.so"
+jemalloc: run
+
+clean:
+	rm -f $(TARGET)

--- a/test/fib/README
+++ b/test/fib/README
@@ -1,0 +1,14 @@
+This is a stress test doing a recursive calculation of Fibonacci numbers.
+To build and run the example for Fib(5), simply "make run". You can change
+the Fibonacci number by setting the WORKLOAD_ARGS environment variable.
+
+    make run WORKLOAD_ARGS=10
+
+By default, the program uses an async/finish strategy to compute Fib(N).
+You can execute a version using futures for synchronization instead
+(i.e., data-driven tasks, or DDTs) by passing a second argument:
+
+    make run WORKLOAD_ARGS="10 DDT"
+
+The value of the second argument doesn't actually matter, since the logic
+just checks to see if it is present.

--- a/test/fib/fib.c
+++ b/test/fib/fib.c
@@ -1,0 +1,190 @@
+#include <stdlib.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <hclib.h>
+#include <assert.h>
+
+#include "hclib.h"
+
+////////////////////////////////////
+// FINISH SCOPE MACRO
+
+#define FINISH GEN_FINISH_SCOPE(MACRO_CONCAT(_hcGenVar_, __COUNTER__))
+#define GEN_FINISH_SCOPE(V) for (int V=(hclib_start_finish(), 1); V; hclib_end_finish(), --V)
+#define MACRO_CONCAT(a, b) DO_MACRO_CONCAT(a, b)
+#define DO_MACRO_CONCAT(a, b) a ## b
+
+
+////////////////////////////////////
+// TIMING HELPER FUNCTIONS
+
+#include <sys/time.h>
+
+static double get_seconds() {
+    struct timeval tv;
+    gettimeofday(&tv, 0);
+    return tv.tv_sec + ((double) tv.tv_usec / 1000000);
+}
+
+void print_throughput(long op_count, double elapsed_seconds) {
+    long throughput = op_count / elapsed_seconds;
+    printf("Throughput (op/s): %ld\n", throughput);
+}
+
+
+////////////////////////////////////
+// ITERATIVE VERSION
+
+long fib_iter(int n) {
+    int i, x, y;
+    for (i=0, x=1, y=0; i<=n; i++) {
+        int t = x;
+        x = y;
+        y += t;
+    }
+    return x;
+}
+
+
+////////////////////////////////////
+// ASYNC-FINISH VERSION
+
+typedef struct {
+    int n;
+    long res;
+} FibArgs;
+
+void fib(void * raw_args) {
+    FibArgs *args = raw_args;
+    if (args->n < 2) {
+        args->res = args->n;
+    }
+    else {
+        FibArgs lhsArgs = { args->n - 1, 0 };
+        FibArgs rhsArgs = { args->n - 2, 0 };
+        FINISH {
+            hclib_async(fib, &lhsArgs, NO_FUTURE, NO_PHASER, ANY_PLACE, NO_PROP);
+            hclib_async(fib, &rhsArgs, NO_FUTURE, NO_PHASER, ANY_PLACE, NO_PROP);
+        }
+        args->res = lhsArgs.res + rhsArgs.res;
+    }
+}
+
+
+////////////////////////////////////
+// DDT VERSION
+
+#if 1
+#define MY_ESCAPE_PROP NO_PROP
+#else
+#define MY_ESCAPE_PROP ESCAPING_ASYNC
+#endif
+
+typedef struct {
+    int n;
+    long resval;
+    hclib_promise_t *res;
+    hclib_promise_t *subres[3];
+} FibDDtArgs;
+
+static FibDDtArgs *setup_fib_ddt_args(int n) {
+    FibDDtArgs *args = malloc(sizeof(*args));
+    args->n = n;
+    args->res = hclib_promise_create();
+    args->subres[2] = NULL;
+    return args;
+}
+
+static void free_ddt_args(FibDDtArgs *args) {
+    hclib_promise_free(args->res);
+    free(args);
+}
+
+static inline void *promise_get(hclib_promise_t *p) {
+    return hclib_future_get(hclib_get_future_for_promise(p));
+}
+
+static inline hclib_future_t **ps2fs(hclib_promise_t **ps) {
+    _Static_assert(offsetof(hclib_promise_t, future) == 0,
+            "can cast promise ptr directly to future ptr");
+    return (hclib_future_t **)ps;
+}
+
+void fib_ddt_res(void * raw_args) {
+    FibDDtArgs *args = raw_args;
+    FibDDtArgs *lhs = promise_get(args->subres[0]);
+    FibDDtArgs *rhs = promise_get(args->subres[1]);
+    args->resval =  lhs->resval + rhs->resval;
+    hclib_promise_put(args->res, args);
+    // cleanup
+    free_ddt_args(lhs);
+    free_ddt_args(rhs);
+}
+
+void fib_ddt(void * raw_args) {
+    FibDDtArgs *args = raw_args;
+    if (args->n < 2) {
+        args->resval = args->n;
+        hclib_promise_put(args->res, args);
+    }
+    else {
+        FibDDtArgs *lhsArgs = setup_fib_ddt_args(args->n - 1);
+        FibDDtArgs *rhsArgs = setup_fib_ddt_args(args->n - 2);
+        args->subres[0] = lhsArgs->res;
+        args->subres[1] = rhsArgs->res;
+        // sub-computation asyncs
+        hclib_async(fib_ddt, lhsArgs, NO_FUTURE, NO_PHASER, ANY_PLACE, MY_ESCAPE_PROP);
+        hclib_async(fib_ddt, rhsArgs, NO_FUTURE, NO_PHASER, ANY_PLACE, MY_ESCAPE_PROP);
+        // async-await for sub-results
+        hclib_async(fib_ddt_res, args, ps2fs(args->subres), NO_PHASER, ANY_PLACE, MY_ESCAPE_PROP);
+    }
+}
+
+void fib_ddt_root_await(void * raw_args) { /* no-op */ }
+
+
+////////////////////////////////////
+// DRIVER
+
+void taskMain(void *raw_args) {
+    char **argv = raw_args;
+    const int n = atoi(argv[1]);
+    const int doDDT = argv[2] && atoi(argv[2]);
+    const long fn = fib_iter(n);
+    const long fnp1 = fib_iter(n+1);
+    long answer;
+    double t_start, t_end;
+    // ASYNC-FINISH version
+    if (!doDDT) {
+        printf("async/finish version\n");
+        t_start = get_seconds();
+        FibArgs args = { n, 0 };
+        FINISH {
+            hclib_async(fib, &args, NO_FUTURE, NO_PHASER, ANY_PLACE, NO_PROP);
+        }
+        t_end = get_seconds();
+        answer = args.res;
+        //printf("asyncs = %ld\tfins=%ld\n", 2*fnp1-1, fnp1);
+    }
+    // DDT version
+    else {
+        printf("DDT version\n");
+        t_start = get_seconds();
+        FibDDtArgs *args = setup_fib_ddt_args(n);
+        FINISH {
+            hclib_async(fib_ddt, args, NO_FUTURE, NO_PHASER, ANY_PLACE, MY_ESCAPE_PROP);
+            args->subres[0] = NULL; // null terminate after res
+            hclib_async(fib_ddt_root_await, args, ps2fs(&args->res), NO_PHASER, ANY_PLACE, NO_PROP);
+        }
+        t_end = get_seconds();
+        answer = args->resval;
+    }
+    print_throughput(fnp1, t_end - t_start);
+    // check results
+    printf("Fib(%d) = %ld = %ld\n", n, fn, answer);
+    assert(answer == fn);
+}
+
+int main(int argc, char ** argv) {
+    hclib_launch(taskMain, argv);
+}


### PR DESCRIPTION
This optimization helps to avoid unnecessary creation of new fibers when the workers aren't doing too much stealing. This change brought the number of fiber-swaps in the Fib(35) test down from over 14 million to just a few hundred.

This should give better performance in many cases, but it's still possible to create a scenario where you get a new fiber per finish scope.
