### PR TITLE
Single type name for loop domains

### DIFF
--- a/inc/hclib-rt.h
+++ b/inc/hclib-rt.h
@@ -95,8 +95,6 @@ typedef struct hclib_worker_state {
 int get_current_worker();
 hclib_worker_state* current_ws();
 
-#define HC_MALLOC(msize)	malloc(msize)
-#define HC_FREE(p)			free(p)
 typedef void (*generic_frame_ptr)(void*);
 
 #include "hclib-timer.h"
@@ -107,8 +105,7 @@ int  hclib_num_workers();
 void hclib_start_finish();
 void hclib_end_finish();
 void hclib_user_harness_timer(double dur);
-void hclib_launch(generic_frame_ptr fct_ptr,
-        void * arg);
+void hclib_launch(generic_frame_ptr fct_ptr, void * arg);
 
 #ifdef __cplusplus
 }

--- a/inc/hclib-task.h
+++ b/inc/hclib-task.h
@@ -57,7 +57,7 @@ typedef struct hclib_dependent_task_t {
  * @param[in] stride    Stride access
  * @param[in] tile      Tile size for chunking
  */
-typedef struct _loop_domain_t {
+typedef struct {
     int low;
     int high;
     int stride;

--- a/inc/hcupc-support.h
+++ b/inc/hcupc-support.h
@@ -105,6 +105,7 @@ inline void execute_hcupc_lambda(T* lambda) {
 			 * lambda into a stack allocated lambda.
 			 */
 
+			// FIXME - what the heck is this doing???
 			/*
 			 * 1. Copy into a char array.
 			 * This user lambda does not have a default constructor / copy constructor and hence we cannot
@@ -121,15 +122,19 @@ inline void execute_hcupc_lambda(T* lambda) {
 			memcpy(commWorkerAsyncAny_infoStruct->ptr_to_outgoingAsyncAny, &tmp, sizeof(remoteAsyncAny_task));
 		}
 	}
-	HC_FREE((void*)lambda);
+	// FIXME - this whole call chain is kind of a mess
+	// leaving C malloc/free and memcpy calls for now (come back to fix it later)
+	free((void*)lambda);
 }
 
 template <typename T>
 inline hclib_task_t* _allocate_async_hcupc(T lambda, bool await) {
+	// FIXME - this whole call chain is kind of a mess
+	// leaving C malloc/free and memcpy calls for now (come back to fix it later)
 	const size_t hclib_task_size = await ? sizeof(hclib_dependent_task_t) : sizeof(hclib_task_t);
-	hclib_task_t* task = (hclib_task_t*) HC_MALLOC(hclib_task_size);
+	hclib_task_t* task = (hclib_task_t*) malloc(hclib_task_size);
 	const size_t lambda_size = sizeof(T);
-	T* lambda_onHeap = (T*) HC_MALLOC(lambda_size);
+	T* lambda_onHeap = (T*) malloc(lambda_size);
 	memcpy(lambda_onHeap, &lambda, lambda_size);
 	hclib_task_t t = hclib_task_t(execute_hcupc_lambda<T>, lambda_onHeap);
 	memcpy(task, &t, sizeof(hclib_task_t));

--- a/scripts/gen-generic-asyncPhased.pl
+++ b/scripts/gen-generic-asyncPhased.pl
@@ -34,8 +34,8 @@ for (my $j=0; $j<$ARGV[0]; $j++) {
 
         my $total = $j + 1;
         print "\tint total = $total;\n";
-        print "\tPHASER_t* phaser_type_arr = (PHASER_t*) HC_MALLOC(sizeof(PHASER_t) * total);\n";
-        print "\tPHASER_m* phaser_mode_arr = (PHASER_m*) HC_MALLOC(sizeof(PHASER_m) * total);\n";
+        print "\tPHASER_t* phaser_type_arr = new PHASER_t[total];\n";
+        print "\tPHASER_m* phaser_mode_arr = new PHASER_m[total];\n";
 
         for (my $i=0; $i<=$j; $i++) {
                 print "\tphaser_type_arr[$i] = ph$i; \n";

--- a/src/hclib-runtime.c
+++ b/src/hclib-runtime.c
@@ -730,7 +730,7 @@ void *gpu_worker_routine(void *finish_ptr) {
                 hclib_promise_put(task->promise_to_put, task->arg_to_put);
             }
 
-            // HC_FREE(task);
+            // free(task);
         }
 
         /*


### PR DESCRIPTION
For some reason we were using two different type names for the loop domain struct. See commit message (b1e6fc2) for details.

---

<i>Note: This pull request builds on #13. You can compare the branches corresponding to the pull requests to see the diff between just #13 and this PR: https://github.com/habanero-rice/hclib/compare/cxx-cleanup...cxx-cleanup-2</i>
