### PR TITLE
Don't memcpy C++ objects

### DIFF
--- a/inc/hclib-async.h
+++ b/inc/hclib-async.h
@@ -74,14 +74,9 @@ inline hclib_task_t* _allocate_async_hclib(T lambda, bool await) {
     hclib_task_t* task = static_cast<hclib_task_t*>(calloc(1, task_size));
     task->_fp = lambda_wrapper<U>;
 
-	const size_t lambda_size = sizeof(T);
-    /*
-     * create off-stack storage for the lambda object (including its captured
-     * variables), which will be pointed to from the task_t.
-     */
-	T* lambda_on_heap = (T*)malloc(lambda_size);
-	memcpy(lambda_on_heap, &lambda, lambda_size);
-    task->args = lambda_on_heap;
+    // make a copy of the user's function object using dynamic storage duration
+    // to ensure that it's still available later.
+    task->args = new U(lambda);
 
     return task;
 }

--- a/inc/hclib-rt.h
+++ b/inc/hclib-rt.h
@@ -95,8 +95,6 @@ typedef struct hclib_worker_state {
 int get_current_worker();
 hclib_worker_state* current_ws();
 
-#define HC_MALLOC(msize)	malloc(msize)
-#define HC_FREE(p)			free(p)
 typedef void (*generic_frame_ptr)(void*);
 
 #include "hclib-timer.h"
@@ -107,8 +105,7 @@ int  hclib_num_workers();
 void hclib_start_finish();
 void hclib_end_finish();
 void hclib_user_harness_timer(double dur);
-void hclib_launch(generic_frame_ptr fct_ptr,
-        void * arg);
+void hclib_launch(generic_frame_ptr fct_ptr, void * arg);
 
 #ifdef __cplusplus
 }

--- a/inc/hclib-task.h
+++ b/inc/hclib-task.h
@@ -57,7 +57,7 @@ typedef struct hclib_dependent_task_t {
  * @param[in] stride    Stride access
  * @param[in] tile      Tile size for chunking
  */
-typedef struct _loop_domain_t {
+typedef struct {
     int low;
     int high;
     int stride;

--- a/inc/hcupc-support.h
+++ b/inc/hcupc-support.h
@@ -103,9 +103,19 @@ inline void execute_hcupc_lambda(T* lambda) {
 			 * If a lambda is heap allocated then the pointer will not be valid at
 			 * remote place. Due to this we have to first copy the content of this
 			 * lambda into a stack allocated lambda.
+			 *
+			 * XXX - This description doesn't make any sense to me.
+			 * There's no way in C++ to differentiate a pointer to
+			 * an object with dynamic vs automatic storage duration,
+			 * so I don't see how this could be true. To further
+			 * complicate this, we're currently using heap-allocated
+			 * stacks for our fibers, so everything is in the heap
+			 * (i.e., even address-range-checking wouldn't work for
+			 * differentiating between stack and heap). This will
+			 * need to be refactored later, but I need to find out
+			 * what exactly it's supposed to be doing first.
 			 */
 
-			// FIXME - what the heck is this doing???
 			/*
 			 * 1. Copy into a char array.
 			 * This user lambda does not have a default constructor / copy constructor and hence we cannot

--- a/inc/hcupc-support.h
+++ b/inc/hcupc-support.h
@@ -105,6 +105,7 @@ inline void execute_hcupc_lambda(T* lambda) {
 			 * lambda into a stack allocated lambda.
 			 */
 
+			// FIXME - what the heck is this doing???
 			/*
 			 * 1. Copy into a char array.
 			 * This user lambda does not have a default constructor / copy constructor and hence we cannot
@@ -121,15 +122,19 @@ inline void execute_hcupc_lambda(T* lambda) {
 			memcpy(commWorkerAsyncAny_infoStruct->ptr_to_outgoingAsyncAny, &tmp, sizeof(remoteAsyncAny_task));
 		}
 	}
-	HC_FREE((void*)lambda);
+	// FIXME - this whole call chain is kind of a mess
+	// leaving C malloc/free and memcpy calls for now (come back to fix it later)
+	free((void*)lambda);
 }
 
 template <typename T>
 inline hclib_task_t* _allocate_async_hcupc(T lambda, bool await) {
+	// FIXME - this whole call chain is kind of a mess
+	// leaving C malloc/free and memcpy calls for now (come back to fix it later)
 	const size_t hclib_task_size = await ? sizeof(hclib_dependent_task_t) : sizeof(hclib_task_t);
-	hclib_task_t* task = (hclib_task_t*) HC_MALLOC(hclib_task_size);
+	hclib_task_t* task = (hclib_task_t*) malloc(hclib_task_size);
 	const size_t lambda_size = sizeof(T);
-	T* lambda_onHeap = (T*) HC_MALLOC(lambda_size);
+	T* lambda_onHeap = (T*) malloc(lambda_size);
 	memcpy(lambda_onHeap, &lambda, lambda_size);
 	hclib_task_t t = hclib_task_t(execute_hcupc_lambda<T>, lambda_onHeap);
 	memcpy(task, &t, sizeof(hclib_task_t));

--- a/scripts/gen-generic-asyncPhased.pl
+++ b/scripts/gen-generic-asyncPhased.pl
@@ -34,8 +34,8 @@ for (my $j=0; $j<$ARGV[0]; $j++) {
 
         my $total = $j + 1;
         print "\tint total = $total;\n";
-        print "\tPHASER_t* phaser_type_arr = (PHASER_t*) HC_MALLOC(sizeof(PHASER_t) * total);\n";
-        print "\tPHASER_m* phaser_mode_arr = (PHASER_m*) HC_MALLOC(sizeof(PHASER_m) * total);\n";
+        print "\tPHASER_t* phaser_type_arr = new PHASER_t[total];\n";
+        print "\tPHASER_m* phaser_mode_arr = new PHASER_m[total];\n";
 
         for (my $i=0; $i<=$j; $i++) {
                 print "\tphaser_type_arr[$i] = ph$i; \n";

--- a/src/hclib-runtime.c
+++ b/src/hclib-runtime.c
@@ -730,7 +730,7 @@ void *gpu_worker_routine(void *finish_ptr) {
                 hclib_promise_put(task->promise_to_put, task->arg_to_put);
             }
 
-            // HC_FREE(task);
+            // free(task);
         }
 
         /*

--- a/test/cpp/.gitignore
+++ b/test/cpp/.gitignore
@@ -19,3 +19,4 @@ forasync3DCh
 forasync3DRec
 neconlce1
 access_argc
+capture[0-9]

--- a/test/cpp/Makefile
+++ b/test/cpp/Makefile
@@ -3,7 +3,8 @@ include $(HCLIB_ROOT)/include/hclib.mak
 TARGETS=async0 async1 finish0 finish1 finish2  forasync1DCh  forasync1DRec \
 		forasync2DCh  forasync2DRec  forasync3DCh  forasync3DRec \
 		promise/asyncAwait0 promise/asyncAwait0Null promise/asyncAwait1 promise/future0 \
-		promise/future1 promise/future2 promise/future3 neconlce1 access_argc
+		promise/future1 promise/future2 promise/future3 neconlce1 access_argc \
+		capture0 capture1
 
 FLAGS=-g -std=c++11
 

--- a/test/cpp/capture0.cpp
+++ b/test/cpp/capture0.cpp
@@ -1,0 +1,63 @@
+/* Copyright (c) 2013, Rice University
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+1.  Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+2.  Redistributions in binary form must reproduce the above
+     copyright notice, this list of conditions and the following
+     disclaimer in the documentation and/or other materials provided
+     with the distribution.
+3.  Neither the name of Rice University
+     nor the names of its contributors may be used to endorse or
+     promote products derived from this software without specific
+     prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+/**
+ * DESC: capture a smart pointer (shared)
+ */
+#include <memory>
+#include <iostream>
+#include <unistd.h>
+#include <cassert>
+
+#include "hclib_cpp.h"
+
+struct SimpleObject {
+    int value;
+    SimpleObject(): value(1) { }
+    ~SimpleObject() { value = 0; }
+};
+
+int main (int argc, char ** argv) {
+    hclib::launch([]() {
+        hclib::finish([]() {{
+            auto p = std::make_shared<SimpleObject>();
+            std::cout << "Value starts as " << p->value << std::endl;
+            hclib::async([=](){
+                usleep(100);
+                std::cout << "Value in async is " << p->value << std::endl;
+                assert(p->value == 1);
+            });
+            // p is dead
+        }});
+    });
+    std::cout << "Exiting..." << std::endl;
+    return 0;
+}

--- a/test/cpp/capture1.cpp
+++ b/test/cpp/capture1.cpp
@@ -1,0 +1,54 @@
+/* Copyright (c) 2013, Rice University
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+1.  Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+2.  Redistributions in binary form must reproduce the above
+     copyright notice, this list of conditions and the following
+     disclaimer in the documentation and/or other materials provided
+     with the distribution.
+3.  Neither the name of Rice University
+     nor the names of its contributors may be used to endorse or
+     promote products derived from this software without specific
+     prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+/**
+ * DESC: Capture an lvalue function object
+ */
+#include <stdlib.h>
+#include <stdio.h>
+#include <assert.h>
+
+#include "hclib_cpp.h"
+
+int ran = 0;
+
+int main (int argc, char ** argv) {
+    hclib::launch([]() {
+        hclib::finish([]() {
+            printf("Hello\n");
+            auto f = [=](){ ran = 1; };
+            hclib::async(f);
+        });
+    });
+    assert(ran == 1);
+    printf("Exiting...\n");
+    return 0;
+}


### PR DESCRIPTION
We should be using C++ copy constructors to copy lambdas into the heap. Bad stuff can happen if we use `memcpy` in C++ (see #12, and the newly-added tests).

I also got rid of two levels of indirection around the lambda used for the async task. I'm pretty sure we didn't need them for anything.

---

<i>Note: This pull request builds on #14. You can compare the branches corresponding to the pull requests to see the diff between just #14 and this PR: https://github.com/habanero-rice/hclib/compare/cxx-cleanup-2...cxx-cleanup-3</i>
