### PR TITLE
Unconstrained promise values

### DIFF
--- a/inc/hclib-async-struct.h
+++ b/inc/hclib-async-struct.h
@@ -64,6 +64,7 @@ void spawn_at_hpt(place_t* pl, hclib_task_t * task);
 void spawn_await_at(hclib_task_t * task, hclib_future_t** future_list,
         place_t *pl);
 void spawn_await(hclib_task_t * task, hclib_future_t** future_list);
+void spawn_escaping(hclib_task_t * task, hclib_future_t** future_list);
 void spawn_comm_task(hclib_task_t * task);
 void spawn_gpu_task(hclib_task_t *task);
 

--- a/inc/hclib-async.h
+++ b/inc/hclib-async.h
@@ -69,9 +69,7 @@ inline hclib_task_t* _allocate_async_hclib(T lambda, bool await) {
     typedef typename std::remove_reference<T>::type U;
     // FIXME - this whole call chain is kind of a mess
     // leaving C malloc/free and memcpy calls for now (come back to fix it later)
-    const size_t task_size =
-        await ? sizeof(hclib_dependent_task_t) : sizeof(hclib_task_t);
-    hclib_task_t* task = static_cast<hclib_task_t*>(calloc(1, task_size));
+    hclib_task_t* task = static_cast<hclib_task_t*>(calloc(1, sizeof(*task)));
     task->_fp = lambda_wrapper<U>;
 
     // make a copy of the user's function object using dynamic storage duration

--- a/inc/hclib-promise.h
+++ b/inc/hclib-promise.h
@@ -94,7 +94,7 @@ typedef struct hclib_triggered_task_st {
 // We define a typedef in this unit for convenience
 typedef struct hclib_promise_st {
     hclib_future_t future;
-	int kind;
+    promise_kind_t kind;
     volatile void *datum;
     // List of tasks that are awaiting the satisfaction of this promise
     volatile hclib_triggered_task_t *wait_list_head;

--- a/inc/hclib-promise.h
+++ b/inc/hclib-promise.h
@@ -95,9 +95,9 @@ typedef struct hclib_triggered_task_st {
 typedef struct hclib_promise_st {
     hclib_future_t future;
     promise_kind_t kind;
-    volatile void *datum;
+    void *volatile datum;
     // List of tasks that are awaiting the satisfaction of this promise
-    volatile hclib_triggered_task_t *wait_list_head;
+    hclib_triggered_task_t *volatile wait_list_head;
 } hclib_promise_t;
 
 /**

--- a/inc/hclib-promise.h
+++ b/inc/hclib-promise.h
@@ -73,23 +73,7 @@ typedef struct _hclib_future_t {
     struct hclib_promise_st *owner;
 } hclib_future_t;
 
-/**
- * An hclib_triggered_task_t associates dependent tasks and the promises that
- * trigger their execution. This is exposed so that the runtime knows the size
- * of the struct.
- */
-typedef struct hclib_triggered_task_st {
-    // NULL-terminated list of futures this task is registered on
-    hclib_future_t **waiting_frontier;
-    /*
-     * This allows us to chain all dependent tasks waiting on a same promise.
-     * Whenever a triggered task wants to register on a promise, and that
-     * promise is not ready, we chain the current triggered task and the
-     * promise's wait_list_head and try to cas on the promise's wait_list_head,
-     * with the current triggered task.
-     */
-    struct hclib_triggered_task_st *next_waiting_on_same_future;
-} hclib_triggered_task_t;
+struct hclib_task_t;
 
 // We define a typedef in this unit for convenience
 typedef struct hclib_promise_st {
@@ -97,7 +81,7 @@ typedef struct hclib_promise_st {
     promise_kind_t kind;
     void *volatile datum;
     // List of tasks that are awaiting the satisfaction of this promise
-    hclib_triggered_task_t *volatile wait_list_head;
+    struct hclib_task_t *volatile wait_list_head;
 } hclib_promise_t;
 
 /**
@@ -160,11 +144,5 @@ void hclib_promise_put(hclib_promise_t *promise, void *datum);
  * that was put on promise.
  */
 void *hclib_future_wait(hclib_future_t *future);
-
-/*
- * Some extras
- */
-void hclib_triggered_task_init(hclib_triggered_task_t *task,
-        hclib_future_t **future_list);
 
 #endif /* HCLIB_PROMISE_H_ */

--- a/inc/hclib-task.h
+++ b/inc/hclib-task.h
@@ -22,7 +22,7 @@
  *      this task depends on to execute, and which it will wait on before
  *      running.
  */
-typedef struct _hclib_task_t {
+typedef struct hclib_task_t {
     void *args;
     struct finish_t *current_finish;
     generic_frame_ptr _fp;
@@ -32,23 +32,11 @@ typedef struct _hclib_task_t {
      * and locality flexible asyncAny
      */
     int is_async_any_type;
+    int future_frontier; // index of next awaited future in list
     hclib_future_t **future_list; // Null terminated list
     place_t *place;
+    struct hclib_task_t *next_waiter;
 } hclib_task_t;
-
-/*
- * A representation of a task whose execution is dependent on prior tasks
- * through a list of promise objects.
- */
-typedef struct hclib_dependent_task_t {
-	hclib_task_t async_task; // the actual task
-    /*
-     * meta-information, tasks that this task is blocked on for execution.
-     * deps.waiting_frontier is generally equal to async_task.future_list. TODO
-     * can we factor out this redundant storage of data?
-     */
-	hclib_triggered_task_t deps;
-} hclib_dependent_task_t;
 
 /** @struct loop_domain_t
  * @brief Describe loop domain when spawning a forasync.
@@ -100,18 +88,5 @@ typedef struct _forasync_3D_task_t {
     hclib_task_t forasync_task;
     forasync3D_t def;
 } forasync3D_task_t;
-
-inline struct finish_t* get_current_finish(hclib_task_t *t) {
-    return t->current_finish;
-}
-
-inline void set_current_finish(hclib_task_t *t,
-        struct finish_t* finish) {
-    t->current_finish = finish;
-}
-
-inline void set_future_list(hclib_task_t *t, hclib_future_t **futures) {
-    t->future_list = futures;
-}
 
 #endif

--- a/inc/hclib_cpp.h
+++ b/inc/hclib_cpp.h
@@ -10,7 +10,6 @@
 
 namespace hclib {
 
-typedef hclib_triggered_task_t triggered_task_t;
 typedef loop_domain_t loop_domain_t;
 typedef place_t place_t;
 typedef place_type_t place_type_t;

--- a/src/inc/hclib-internal.h
+++ b/src/inc/hclib-internal.h
@@ -75,6 +75,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // Default value of a promise datum
 #define UNINITIALIZED_PROMISE_DATA_PTR NULL
 
+// For waiting frontier (last element of the list)
+#define SATISFIED_FUTURE_WAITLIST_PTR NULL
+#define SENTINEL_FUTURE_WAITLIST_PTR ((void*) -1)
+
 typedef struct {
     volatile uint64_t flag;
     void * pad[CACHE_LINE_L1-1];
@@ -130,5 +134,9 @@ int get_current_worker();
 int register_on_all_promise_dependencies(hclib_task_t *task);
 void try_schedule_async(hclib_task_t * async_task, int comm_task, int gpu_task,
         hclib_worker_state *ws);
+
+int static inline _hclib_promise_is_satisfied(hclib_promise_t *p) {
+    return p->wait_list_head == SATISFIED_FUTURE_WAITLIST_PTR;
+}
 
 #endif /* HCLIB_INTERNAL_H_ */

--- a/src/inc/hclib-internal.h
+++ b/src/inc/hclib-internal.h
@@ -73,7 +73,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define CACHE_LINE_L1 8
 
 // Default value of a promise datum
-#define UNINITIALIZED_PROMISE_DATA_PTR ((void *)-1)
+#define UNINITIALIZED_PROMISE_DATA_PTR NULL
 
 typedef struct {
     volatile uint64_t flag;

--- a/src/inc/hclib-internal.h
+++ b/src/inc/hclib-internal.h
@@ -127,9 +127,7 @@ void bind_thread(int worker_id, int *bind_map, int bind_map_size);
 int get_current_worker();
 
 // promise
-int register_on_all_promise_dependencies(hclib_triggered_task_t *tasks);
-hclib_triggered_task_t * rt_async_task_to_triggered_task(
-        hclib_task_t * async_task);
+int register_on_all_promise_dependencies(hclib_task_t *task);
 void try_schedule_async(hclib_task_t * async_task, int comm_task, int gpu_task,
         hclib_worker_state *ws);
 

--- a/test/c/promise/asyncAwait0.c
+++ b/test/c/promise/asyncAwait0.c
@@ -36,13 +36,13 @@ void entrypoint(void *arg) {
     for (index = 0 ; index <= n; index++) {
         promise_list[index * 2] = hclib_promise_create();
         future_list[index * 2] = hclib_get_future_for_promise(promise_list[index * 2]);
-        printf("Creating promise  %p at promise_list @ %p \n", &promise_list[index*2],
-                hclib_future_get(hclib_get_future_for_promise(promise_list[index * 2])));
+        printf("Creating promise  %p at promise_list @ %p \n",
+                &promise_list[index*2], promise_list[index * 2]);
         promise_list[index * 2 + 1] = NULL;
         future_list[index * 2 + 1] = NULL;
     }
 
-    for (index = n - 1; index >= 1; index--) {
+    for (index = n; index >= 1; index--) {
         printf("Creating async %d\n", index);
         // Build async's arguments
         void ** argv = malloc(sizeof(void *) * 2);

--- a/test/c/promise/asyncAwait0Null.c
+++ b/test/c/promise/asyncAwait0Null.c
@@ -35,12 +35,12 @@ void entrypoint(void *arg) {
         promise_list[index * 2] = hclib_promise_create();
         future_list[index * 2] = hclib_get_future_for_promise(promise_list[index * 2]);
 
-        printf("Creating promise  %p at promise_list @ %p \n", &promise_list[index*2],
-                hclib_future_get(future_list[index*2]));
+        printf("Creating promise  %p at promise_list @ %p \n",
+                &promise_list[index*2], future_list[index*2]);
         promise_list[index*2+1] = NULL;
         future_list[index * 2 + 1] = NULL;
     }
-    for(index=n-1; index>=1; index--) {
+    for(index=n; index>=1; index--) {
         printf("Creating async %d\n", index);
         // Build async's arguments
         void ** argv = malloc(sizeof(void *) * 2);
@@ -57,7 +57,6 @@ void entrypoint(void *arg) {
     hclib_end_finish();
     // freeing everything up
     for (index = 0 ; index <= n; index++) {
-        free(hclib_future_get(future_list[index*2]));
         hclib_promise_free(promise_list[index*2]);
     }
     free(promise_list);

--- a/test/c/promise/asyncAwait1.c
+++ b/test/c/promise/asyncAwait1.c
@@ -48,7 +48,7 @@ void entrypoint(void *arg) {
         future_list[index * 2 + 1] = NULL;
     }
 
-    for(index=n-1; index>=1; index--) {
+    for(index=n; index>=1; index--) {
         // Build async's arguments
         // Pass down the whole promise_list, and async uses index*2 to resolve promises it needs
         void ** argv = malloc(sizeof(void *) * 3);

--- a/test/cpp/promise/asyncAwait0.cpp
+++ b/test/cpp/promise/asyncAwait0.cpp
@@ -32,7 +32,7 @@ int main(int argc, char ** argv) {
                 promise_list[index*2+1] = NULL;
             }
 
-            for (index = n - 1; index >= 1; index--) {
+            for (index = n; index >= 1; index--) {
                 printf("Creating async %d\n", index);
                 // Build async's arguments
                 printf("Creating async %d await on %p will enable %p\n", index,

--- a/test/cpp/promise/asyncAwait0Null.cpp
+++ b/test/cpp/promise/asyncAwait0Null.cpp
@@ -11,16 +11,6 @@
 
 #include "hclib_cpp.h"
 
-void async_fct(void * arg) {
-    void ** argv = (void **) arg;
-    int index = *((int *) argv[0]);
-    hclib::promise_t * promise = (hclib::promise_t *) argv[1];
-    printf("Running async %d\n", index/2);
-    printf("Async %d putting in promise %d @ %p\n", index/2, index, promise);
-    promise->put(NO_DATUM);
-    free(argv);
-}
-
 /*
  * Create async await and enable them (by a put) in the 
  * reverse order they've been created.
@@ -42,7 +32,7 @@ int main(int argc, char ** argv) {
                 promise_list[index*2+1] = NULL;
             }
 
-            for(index=n-1; index>=1; index--) {
+            for(index=n; index>=1; index--) {
                 printf("Creating async %d\n", index);
                 // Build async's arguments
                 printf("Creating async %d await on %p will enable %p\n", index,
@@ -56,7 +46,6 @@ int main(int argc, char ** argv) {
         });
         // freeing everything up
         for (int index = 0 ; index <= n; index++) {
-            free(promise_list[index*2]->get_future()->get());
             delete promise_list[index*2];
         }
         free(promise_list);

--- a/test/cpp/promise/asyncAwait1.cpp
+++ b/test/cpp/promise/asyncAwait1.cpp
@@ -12,21 +12,6 @@
 
 #include "hclib_cpp.h"
 
-void async_fct(void * arg) {
-    void ** argv = (void **) arg;
-    int index = *((int *) argv[0]);
-    hclib::promise_t ** promise_list = (hclib::promise_t **) argv[1];
-    printf("Running async %d\n", index);
-    /* Check value set by predecessor */
-    int* prev = (int *) promise_list[(index-1)*2]->get_future()->get();
-    assert(*prev == index-1);
-    printf("Async %d putting in promise %d @ %p\n", index, index*2, promise_list[index*2]);
-    int * value = (int *) malloc(sizeof(int)*1);
-    *value = index;
-    promise_list[index*2]->put(value);
-    free(argv);
-}
-
 /*
  * Create async await and enable them (by a put) in the 
  * reverse order they've been created.
@@ -48,7 +33,7 @@ int main(int argc, char ** argv) {
                 promise_list[index*2+1] = NULL;
             }
 
-            for(index=n-1; index>=1; index--) {
+            for(index=n; index>=1; index--) {
                 // Build async's arguments
                 printf("Creating async %d await on %p will enable %p\n", index,
                         promise_list, &(promise_list[index*2]));


### PR DESCRIPTION
You should be able to store whatever you want in a promise. The restriction on the promise payload value was carried over from the old HC runtime (although I'm not sure how necessary it was there either). We just check the `wait_list_head` to see if a promise is satisfied. This might add a bit of overhead compared to directly checking the value of `datum`, but I wouldn't expect the difference to be significant (the two fields are probably on the same cache line).

Managing all of the casts back and forth between the "dependent task" type and the normal task type was giving me a headache, so I collapsed both types back into the normal task type. We might want to split them up again later, but having just one task type while doing this refactoring meant one less thing that I had to worry about. Since the overhead of combining the two is just one pointer field, I don't think it will cause too much concern for now.

Both of these changes lay groundwork for changes in the C++ API in later commits, such as template specializations of the promise type, and code consolidation for task management.

There are also some fixes for bugs in the test suite that were uncovered while refactoring.

---

<i>Note: This pull request builds on #15. You can compare the branches corresponding to the pull requests to see the diff between just #15 and this PR: https://github.com/habanero-rice/hclib/compare/cxx-cleanup-3...cxx-cleanup-4</i>
