### PR TITLE
C++ async and forasync delegate to C API

### DIFF
--- a/inc/hclib-forasync.h
+++ b/inc/hclib-forasync.h
@@ -62,537 +62,169 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 namespace hclib {
 
-template <typename T>
-inline void forasync1D_runner(loop_domain_t* loop, T lambda) {
-	loop_domain_t loop0 = loop[0];
-	for(int i=loop0.low; i<loop0.high; i+=loop0.stride) {
-		lambda(i);
-	}
+union ForAsyncFpUnion {
+    forasync1D_Fct_t f1;
+    forasync2D_Fct_t f2;
+    forasync3D_Fct_t f3;
+    void *vp;
+};
+
+template<typename T>
+void forasync1D_wrapper(void *arg, int i) {
+    T* lambda = static_cast<T*>(arg);
+    (*lambda)(i);
+    // FIXME - memory leak
+    // we can't delete this here (it's called in a loop)
+    // delete lambda;
 }
 
 template <typename T>
-inline void forasync2D_runner(const loop_domain_t loop[2], T lambda) {
-	loop_domain_t loop0 = loop[0];
-	loop_domain_t loop1 = loop[1];
-	for(int i=loop0.low; i<loop0.high; i+=loop0.stride) {
-		for(int j=loop1.low; j<loop1.high; j+=loop1.stride) {
-			lambda(i, j);
-		}
-	}
-}
-
-template <typename T>
-inline void forasync3D_runner(const loop_domain_t loop[3], T lambda) {
-	loop_domain_t loop0 = loop[0];
-	loop_domain_t loop1 = loop[1];
-	loop_domain_t loop2 = loop[2];
-	for (int i = loop0.low; i < loop0.high; i += loop0.stride) {
-		for (int j = loop1.low; j < loop1.high; j += loop1.stride) {
-			for (int k = loop2.low; k < loop2.high; k += loop2.stride) {
-				lambda(i, j, k);
-			}
-		}
-	}
-}
-
-template <typename T>
-inline void forasync1D_recursive(loop_domain_t* loop, T lambda,
-        place_t *place, hclib_future_t **future_list) {
-	int low = loop->low, high = loop->high, stride = loop->stride, tile = loop->tile;
-	//split the range into two, spawn a new task for the first half and recurse on the rest
-	if ((high-low) > tile) {
-		int mid = (high+low)/2;
-		// upper-half
-		// delegate scheduling to the underlying runtime
-        auto lambda_wrapper = [=]() {
-            loop_domain_t ld = {mid, high, stride, tile};
-            forasync1D_recursive<T>(&ld, lambda, place, future_list);
-        };
-
-        hclib::async_await_at(lambda_wrapper, place, future_list);
-		// update lower-half
-		//continue to work on the half task
-		loop_domain_t ld = {low, mid, stride, tile};
-		forasync1D_recursive<T>(&ld, lambda, place, future_list);
-	} else {
-		//compute the tile
-		loop_domain_t ld = {low, high, stride, tile};
-		forasync1D_runner<T>(&ld, lambda);
-	}
-}
-
-template <typename T>
-inline void forasync2D_recursive(const loop_domain_t loop[2], T lambda,
-        place_t *place, hclib_future_t **future_list) {
-	loop_domain_t loop0 = loop[0];
-	int high0 = loop0.high;
-	int low0 = loop0.low;
-	int stride0 = loop0.stride;
-	int tile0 = loop0.tile;
-
-	loop_domain_t loop1 = loop[1];
-	int high1 = loop1.high;
-	int low1 = loop1.low;
-	int stride1 = loop1.stride;
-	int tile1 = loop1.tile;
-
-	//split the range into two, spawn a new task for the first half and recurse on the rest
-	loop_domain_t new_loop[2];
-	bool new_loop_initialized = false;
-
-	if((high0-low0) > tile0) {
-		int mid = (high0+low0)/2;
-		// upper-half
-		new_loop[0] = {mid, high0, stride0, tile0};
-		new_loop[1] = {low1, high1, stride1, tile1};
-		// update lower-half
-		high0 = mid;
-		new_loop_initialized = true;
-	} else if((high1-low1) > tile1) {
-		int mid = (high1+low1)/2;
-		// upper-half
-		new_loop[0] = {low0, high0, stride0, tile0};
-		new_loop[1] = {mid, high1, stride1, tile1};
-		// update lower-half
-		high1 = mid;
-		new_loop_initialized = true;
-	}
-	// recurse
-	if(new_loop_initialized) {
-		// delegate scheduling to the underlying runtime
-        auto lambda_wrapper = [=]() {
-            forasync2D_recursive<T>(new_loop, lambda, place, future_list);
-        };
-
-        hclib::async_await_at(lambda_wrapper, place, future_list);
-
-		//continue to work on the half task
-		loop_domain_t new_loop_lower_half[2] = {
-				{low0, high0, stride0, tile0},
-				{low1, high1, stride1, tile1}
-		};
-		forasync2D_recursive<T>(new_loop_lower_half, lambda, place, future_list);
-	} else { //compute the tile
-		forasync2D_runner<T>(loop, lambda);
-	}
-}
-
-template <typename T>
-inline void forasync3D_recursive(const loop_domain_t loop[3], T lambda,
-        place_t *place, hclib_future_t **future_list) {
-	loop_domain_t loop0 = loop[0];
-	int high0 = loop0.high;
-	int low0 = loop0.low;
-	int stride0 = loop0.stride;
-	int tile0 = loop0.tile;
-
-	loop_domain_t loop1 = loop[1];
-	int high1 = loop1.high;
-	int low1 = loop1.low;
-	int stride1 = loop1.stride;
-	int tile1 = loop1.tile;
-
-	loop_domain_t loop2 = loop[2];
-	int high2 = loop2.high;
-	int low2 = loop2.low;
-	int stride2 = loop2.stride;
-	int tile2 = loop2.tile;
-
-	//split the range into two, spawn a new task for the first half and recurse on the rest
-	loop_domain_t new_loop[3];
-	bool new_loop_initialized = false;
-
-	if((high0-low0) > tile0) {
-		int mid = (high0+low0)/2;
-		// upper-half
-		new_loop[0] = {mid, high0, stride0, tile0};
-		new_loop[1] = {low1, high1, stride1, tile1};
-		new_loop[2] = {low2, high2, stride2, tile2};
-		// update lower-half
-		high0 = mid;
-		new_loop_initialized = true;
-	} else if((high1-low1) > tile1) {
-		int mid = (high1+low1)/2;
-		// upper-half
-		new_loop[0] = {low0, high0, stride0, tile0};
-		new_loop[1] = {mid, high1, stride1, tile1};
-		new_loop[2] = {low2, high2, stride2, tile2};
-		// update lower-half
-		high1 = mid;
-		new_loop_initialized = true;
-	} else if((high2-low2) > tile2) {
-		int mid = (high2+low2)/2;
-		// upper-half
-		new_loop[0] = {low0, high0, stride0, tile0};
-		new_loop[1] = {low1, high1, stride1, tile1};
-		new_loop[2] = {mid, high2, stride2, tile2};
-		// update lower-half
-		high2 = mid;
-		new_loop_initialized = true;
-	}
-	// recurse
-	if (new_loop_initialized) {
-		// delegate scheduling to the underlying runtime
-        auto lambda_wrapper = [=]() {
-			forasync3D_recursive<T>(new_loop, lambda, place, future_list);
-		};
-
-        hclib::async_await_at(lambda_wrapper, place, future_list);
-
-		//continue to work on the half task
-		loop_domain_t new_loop_lower_half[3] = {
-				{low0, high0, stride0, tile0},
-				{low1, high1, stride1, tile1},
-				{low2, high2, stride2, tile2}
-		};
-		forasync3D_recursive<T>(new_loop_lower_half, lambda, place, future_list);
-	} else { //compute the tile
-		forasync3D_runner<T>(loop, lambda);
-	}
-}
-
-template <typename T>
-inline void forasync1D_flat(loop_domain_t* loop, T lambda, place_t *place,
-        hclib_future_t **future_list) {
-	int low=loop->low, high=loop->high, stride=loop->stride, tile=loop->tile;
-	int nb_chunks = (int) (high/tile);
-	int size = tile*nb_chunks;
-	int low0;
-	for(low0 = low; low0<size; low0+=tile) {
-        auto lambda_wrapper = [=]() {
-			loop_domain_t ld = {low0, low0+tile, stride, tile};
-			forasync1D_runner<T>(&ld, lambda);
-		};
-
-        hclib::async_await_at(lambda_wrapper, place, future_list);
-	}
-	// handling leftover
-	if (size < high) {
-        auto lambda_wrapper = [=]() {
-			loop_domain_t ld = {low0, high, stride, tile};
-			forasync1D_runner<T>(&ld, lambda);
-		};
-        hclib::async_await_at(lambda_wrapper, place, future_list);
-	}
-}
-
-template <typename T>
-inline void forasync2D_flat(const loop_domain_t loop[2], T lambda,
-        place_t *place, hclib_future_t **future_list) {
-	loop_domain_t loop0 = loop[0];
-	int high0 = loop0.high;
-	int low0 = loop0.low;
-	int stride0 = loop0.stride;
-	int tile0 = loop0.tile;
-
-	loop_domain_t loop1 = loop[1];
-	int high1 = loop1.high;
-	int low1 = loop1.low;
-	int stride1 = loop1.stride;
-	int tile1 = loop1.tile;
-
-	for(int low0a=low0; low0a<high0; low0a+=tile0) {
-		int high0a = (low0a+tile0)>high0?high0:(low0a+tile0);
-		for(int low1a=low1; low1a<high1; low1a+=tile1) {
-			int high1a = (low1a+tile1)>high1?high1:(low1a+tile1);
-			loop_domain_t new_loop0 = {low0a, high0a, stride0, tile0};
-			loop_domain_t new_loop1 = {low1a, high1a, stride1, tile1};
-			loop_domain_t new_loop[2] = {new_loop0, new_loop1};
-
-            auto lambda_wrapper = [=]() {
-				forasync2D_runner<T>(new_loop, lambda);
-			};
-
-            hclib::async_await_at(lambda_wrapper, place, future_list);
-		}
-	}
-}
-
-template <typename T>
-inline void forasync3D_flat(const loop_domain_t loop[3], T lambda,
-        place_t *place, hclib_future_t **future_list) {
-	loop_domain_t loop0 = loop[0];
-	int high0 = loop0.high;
-	int low0 = loop0.low;
-	int stride0 = loop0.stride;
-	int tile0 = loop0.tile;
-
-	loop_domain_t loop1 = loop[1];
-	int high1 = loop1.high;
-	int low1 = loop1.low;
-	int stride1 = loop1.stride;
-	int tile1 = loop1.tile;
-
-	loop_domain_t loop2 = loop[2];
-	int high2 = loop2.high;
-	int low2 = loop2.low;
-	int stride2 = loop2.stride;
-	int tile2 = loop2.tile;
-
-	for(int low0a=low0; low0a<high0; low0a+=tile0) {
-		int high0a = (low0a+tile0)>high0?high0:(low0a+tile0);
-		for(int low1a=low1; low1a<high1; low1a+=tile1) {
-			int high1a = (low1a+tile1)>high1?high1:(low1a+tile1);
-			for(int low2a=low2; low2a<high2; low2a+=tile2) {
-				int high2a = (low2a+tile2)>high2?high2:(low2a+tile2);
-				loop_domain_t new_loop0 = {low0a, high0a, stride0, tile0};
-				loop_domain_t new_loop1 = {low1a, high1a, stride1, tile1};
-				loop_domain_t new_loop2 = {low2a, high2a, stride2, tile2};
-				loop_domain_t new_loop[3] = {new_loop0, new_loop1, new_loop2};
-
-                auto lambda_wrapper = [=]() {
-					forasync3D_runner<T>(new_loop, lambda);
-				};
-
-                hclib::async_await_at(lambda_wrapper, place, future_list);
-			}
-		}
-	}
-}
-
-template <typename T>
-inline void forasync1D_internal(loop_domain_t* loop, T lambda, int mode,
-        place_t *place, hclib_future_t **future_list) {
-	switch(mode) {
-	case FORASYNC_MODE_FLAT:
-		forasync1D_flat<T>(loop, lambda, place, future_list);
-		break;
-	case FORASYNC_MODE_RECURSIVE:
-		forasync1D_recursive<T>(loop, lambda, place, future_list);
-		break;
-	default:
-		HASSERT("Check forasync mode" && false);
-	}
-}
-
-template <typename T>
-inline void forasync2D_internal(const loop_domain_t loop[2], T lambda,
-        int mode, place_t *place, hclib_future_t **future_list) {
-	switch(mode) {
-	case FORASYNC_MODE_FLAT:
-		forasync2D_flat<T>(loop, lambda, place, future_list);
-		break;
-	case FORASYNC_MODE_RECURSIVE:
-		forasync2D_recursive<T>(loop, lambda, place, future_list);
-		break;
-	default:
-		HASSERT("Check forasync mode" && false);
-	}
-}
-
-template <typename T>
-inline void forasync3D_internal(const loop_domain_t loop[3], T lambda,
-        int mode, place_t *place, hclib_future_t **future_list) {
-	switch(mode) {
-	case FORASYNC_MODE_FLAT:
-		forasync3D_flat<T>(loop, lambda, place, future_list);
-		break;
-	case FORASYNC_MODE_RECURSIVE:
-		forasync3D_recursive<T>(loop, lambda, place, future_list);
-		break;
-	default:
-		HASSERT("Check forasync mode" && false);
-	}
-}
-
-#ifdef HC_CUDA
-
-#ifdef __CUDACC__
-template<typename functor_type>
-static __global__ void driver_kernel(functor_type functor, unsigned niters) {
-    const int tid = blockIdx.x * blockDim.x + threadIdx.x;
-    if (tid < niters) {
-        functor(tid);
-    }
-}
-
-template <typename functor_type>
-inline void call_gpu_functor(unsigned niters, unsigned tile_size,
-        cudaStream_t stream, void* functor) {
-    functor_type *actual = (functor_type *)functor;
-
-    const unsigned block_size = tile_size;
-    const unsigned nblocks = (niters + block_size - 1) / block_size;
-
-    driver_kernel<<<nblocks, block_size, 0, stream>>>(*actual, niters);
-}
-
-#endif
-
-template<class functor_type>
-inline void forasync1D_cuda_internal(loop_domain_t *loop,
-        functor_type functor, int mode, place_t *place,
-        hclib_future_t **future_list, hclib_promise_t *out_promise) {
-#ifdef __CUDACC__
-    HASSERT(loop->stride == 1);
-    HASSERT(loop->low == 0);
-    HASSERT(loop->tile > 0);
-    HASSERT(loop->high > 0);
-    HASSERT(mode == FORASYNC_MODE_FLAT);
-
-    functor_type *functor_on_heap = (functor_type *)malloc(
-            sizeof(functor_type));
-    HASSERT(functor_on_heap);
-    memcpy(functor_on_heap, &functor, sizeof(functor_type));
-
-    gpu_functor_wrapper *wrapper = (gpu_functor_wrapper *)malloc(
-            sizeof(gpu_functor_wrapper));
-    wrapper->functor_on_heap = functor_on_heap;
-    wrapper->functor_caller = call_gpu_functor<functor_type>;
-
-    gpu_task_t *task = (gpu_task_t *)malloc(sizeof(gpu_task_t));
-    HASSERT(task);
-    task->t._fp = NULL;
-    task->t.is_async_any_type = 0;
-    task->t.future_list = NULL;
-    task->t.args = NULL;
-
-    if (out_promise) hclib_promise_init(out_promise);
-    task->gpu_type = GPU_COMPUTE_TASK;
-    task->promise_to_put = out_promise;
-    task->arg_to_put = NULL;
-    task->gpu_task_def.compute_task.niters = loop->high;
-    task->gpu_task_def.compute_task.tile_size = loop->tile;
-    task->gpu_task_def.compute_task.stream = place->cuda_stream;
-    task->gpu_task_def.compute_task.cuda_id = place->cuda_id;
-    task->gpu_task_def.compute_task.kernel_launcher = wrapper;
-
-    if (future_list) {
-        hclib::async_await([task]() { spawn_gpu_task((hclib_task_t *)task); },
-                future_list);
-    } else {
-        spawn_gpu_task((hclib_task_t *)task);
-    }
-#else
-    fprintf(stderr, "Application code must be compiled with nvcc to "
-            "support GPU tasks. The functor declaration and the forasync "
-            "call site must also be in a .cu file\n");
-    HASSERT(0);
-#endif
-}
-
-#endif
-
-/*
- * NOTE: We tried to get this API to support passing device lambdas. However,
- * despite some indications in the CUDA docs that they support
- * __host__ __device__ lambdas, this does not seem to be the case. Because of
- * this, supporting lambdas that are only __device__ would restrict the
- * flexibility of this API and require a dedicated forasync_gpu function (or
- * some equivalent), which is not what we want here. If NVIDIA's lambda support
- * improves in the future, this API would theoretically work out-of-the-box with
- * lambdas, but for now it doesn't seem reasonable to support them.
- *
- * As a result, if a GPU place is specified the lambda argument should not
- * actually be a C++11 lambda, but rather a C++ functor with the () operator
- * overloaded.
- *
- * The same is true for forasync1D_future.
- */
-template <typename T>
-inline void forasync1D(loop_domain_t* loop, T lambda,
+inline void forasync1D(loop_domain_t* loop, T &&lambda,
         int mode = FORASYNC_MODE_RECURSIVE, place_t *place = NULL,
         hclib_future_t **future_list = NULL) {
-    if (place == NULL || is_cpu_place(place)) {
-        forasync1D_internal<T>(loop, lambda, mode, place, future_list);
-#ifdef HC_CUDA
-    } else if (is_nvgpu_place(place)) {
-        forasync1D_cuda_internal(loop, lambda, mode, place, future_list, NULL);
-#endif
-    } else {
-        fprintf(stderr, "Unrecognized place type %d\n", place->type);
-        exit(1);
+    HASSERT(place == NULL || is_cpu_place(place));
+    constexpr int DIM = 1;
+    // copy lambda
+    typedef typename std::remove_reference<T>::type U;
+    U *arg = new U(lambda);
+    // set up wrapper function
+    ForAsyncFpUnion fp;
+    fp.f1 = forasync1D_wrapper<U>;
+    HASSERT_STATIC(sizeof(fp.f1) == sizeof(fp.vp), "can pass as void*");
+    // launch
+    if (place || future_list) {
+        loop_domain_t domain[] = { loop[0] };
+        async_await_at([=]{
+                HASSERT_STATIC(sizeof(domain) == sizeof(*domain) * DIM,
+                        "The whole domain is captured by value");
+                hclib_forasync(fp.vp, arg, nullptr, DIM, domain, mode);
+            }, place, future_list);
+    }
+    else {
+        hclib_forasync(fp.vp, arg, nullptr, DIM, loop, mode);
     }
 }
 
-template <typename T>
-inline void forasync2D(loop_domain_t* loop, T lambda,
-        int mode = FORASYNC_MODE_RECURSIVE, place_t *place = NULL,
-        hclib_future_t **future_list = NULL) {
-    forasync2D_internal<T>(loop, lambda, mode, place, future_list);
+template<typename T>
+void forasync2D_wrapper(void *arg, int i, int j) {
+    T* lambda = static_cast<T*>(arg);
+    (*lambda)(i, j);
+    // FIXME - memory leak
+    // we can't delete this here (it's called in a loop)
+    // delete lambda;
 }
 
 template <typename T>
-inline void forasync3D(loop_domain_t* loop, T lambda,
+inline void forasync2D(loop_domain_t* loop, T &&lambda,
         int mode = FORASYNC_MODE_RECURSIVE, place_t *place = NULL,
         hclib_future_t **future_list = NULL) {
-    forasync3D_internal<T>(loop, lambda, mode, place, future_list);
-}
-
-template <typename T>
-inline hclib::future_t *forasync1D_future(loop_domain_t* loop, T lambda,
-        int mode, place_t *place, hclib_future_t **future_list) {
-#ifdef VERBOSE
-    int place_device_id = -1;
-#ifdef HC_CUDA
-    if (place) place_device_id = place->cuda_id;
-#endif
-    fprintf(stderr, "forasync1D_future: place=%p cuda_id=%d\n", place,
-            place_device_id);
-#endif
-    if (place == NULL || is_cpu_place(place)) {
-        hclib_start_finish();
-        forasync1D_internal<T>(loop, lambda, mode, place, NULL);
-        hclib::promise_t *event = new hclib::promise_t();
-        hclib_end_finish_nonblocking_helper(&event->internal);
-        return event->get_future();
-#ifdef HC_CUDA
-    } else if (is_nvgpu_place(place)) {
-        hclib::promise_t *event = new hclib::promise_t();
-        forasync1D_cuda_internal(loop, lambda, mode, place, NULL,
-                &event->internal);
-        return event->get_future();
-#endif
-    } else {
-        fprintf(stderr, "Unrecognized place type %d\n", place->type);
-        exit(1);
+    HASSERT(place == NULL || is_cpu_place(place));
+    constexpr int DIM = 2;
+    // copy lambda
+    typedef typename std::remove_reference<T>::type U;
+    U *arg = new U(lambda);
+    // set up wrapper function
+    ForAsyncFpUnion fp;
+    fp.f2 = forasync2D_wrapper<U>;
+    HASSERT_STATIC(sizeof(fp.f2) == sizeof(fp.vp), "can pass as void*");
+    // launch
+    if (place || future_list) {
+        loop_domain_t domain[] = { loop[0], loop[1] };
+        async_await_at([=]{
+                HASSERT_STATIC(sizeof(domain) == sizeof(*domain) * DIM,
+                        "The whole domain is captured by value");
+                hclib_forasync(fp.vp, arg, nullptr, DIM, domain, mode);
+            }, place, future_list);
+    }
+    else {
+        hclib_forasync(fp.vp, arg, nullptr, DIM, loop, mode);
     }
 }
 
-template <typename T>
-inline hclib::future_t *forasync1D_future(loop_domain_t* loop, T lambda) {
-    return forasync1D_future(loop, lambda, FORASYNC_MODE_RECURSIVE, NULL, NULL);
+template<typename T>
+void forasync3D_wrapper(void *arg, int i, int j, int k) {
+    T* lambda = static_cast<T*>(arg);
+    (*lambda)(i, j, k);
+    // FIXME - memory leak
+    // we can't delete this here (it's called in a loop)
+    // delete lambda;
 }
 
 template <typename T>
-inline hclib::future_t *forasync1D_future(loop_domain_t* loop, T lambda,
-        int mode) {
-    return forasync1D_future(loop, lambda, mode, NULL, NULL);
+inline void forasync3D(loop_domain_t* loop, T &&lambda,
+        int mode = FORASYNC_MODE_RECURSIVE, place_t *place = NULL,
+        hclib_future_t **future_list = NULL) {
+    HASSERT(place == NULL || is_cpu_place(place));
+    constexpr int DIM = 3;
+    // copy lambda
+    typedef typename std::remove_reference<T>::type U;
+    U *arg = new U(lambda);
+    // set up wrapper function
+    ForAsyncFpUnion fp;
+    fp.f3 = forasync3D_wrapper<U>;
+    HASSERT_STATIC(sizeof(fp.f3) == sizeof(fp.vp), "can pass as void*");
+    // launch
+    if (place || future_list) {
+        loop_domain_t domain[] = { loop[0], loop[1], loop[2] };
+        async_await_at([=]{
+                HASSERT_STATIC(sizeof(domain) == sizeof(*domain) * DIM,
+                        "the whole domain is captured by value");
+                hclib_forasync(fp.vp, arg, nullptr, DIM, domain, mode);
+            }, place, future_list);
+    }
+    else {
+        hclib_forasync(fp.vp, arg, nullptr, DIM, loop, mode);
+    }
+}
+
+
+template <typename T>
+inline hclib::future_t *forasync1D_future(loop_domain_t* loop, T &&lambda,
+        int mode = FORASYNC_MODE_RECURSIVE, place_t *place = NULL,
+        hclib_future_t **future_list = NULL) {
+    hclib_start_finish();
+    forasync1D(loop, std::forward<decltype(lambda)>(lambda),
+            mode, place, future_list);
+    // FIXME - memory leak? (no handle to destroy the promise)
+    hclib::promise_t *event = new hclib::promise_t();
+    hclib_end_finish_nonblocking_helper(&event->internal);
+    return event->get_future();
 }
 
 template <typename T>
-inline hclib::future_t *forasync1D_future(loop_domain_t* loop, T lambda,
-        int mode, place_t *place) {
-    return forasync1D_future(loop, lambda, mode, place, NULL);
+inline hclib::future_t *forasync2D_future(loop_domain_t* loop, T &&lambda,
+        int mode = FORASYNC_MODE_RECURSIVE, place_t *place = NULL,
+        hclib_future_t **future_list = NULL) {
+    hclib_start_finish();
+    forasync2D(loop, std::forward<decltype(lambda)>(lambda),
+            mode, place, future_list);
+    // FIXME - memory leak? (no handle to destroy the promise)
+    hclib::promise_t *event = new hclib::promise_t();
+    hclib_end_finish_nonblocking_helper(&event->internal);
+    return event->get_future();
 }
 
+template <typename T>
+inline hclib::future_t *forasync3D_future(loop_domain_t* loop, T &&lambda,
+        int mode = FORASYNC_MODE_RECURSIVE, place_t *place = NULL,
+        hclib_future_t **future_list = NULL) {
+    hclib_start_finish();
+    forasync3D(loop, std::forward<decltype(lambda)>(lambda),
+            mode, place, future_list);
+    // FIXME - memory leak? (no handle to destroy the promise)
+    hclib::promise_t *event = new hclib::promise_t();
+    hclib_end_finish_nonblocking_helper(&event->internal);
+    return event->get_future();
+}
+
+// TODO - Do we also need parameter-pack versions of the other forasyncs?
 template <typename T, typename... future_list_t>
-inline hclib::future_t *forasync1D_future(loop_domain_t* loop, T lambda,
+inline hclib::future_t *forasync1D_future(loop_domain_t* loop, T &&lambda,
         int mode, place_t *place, future_list_t... futures) {
+    // FIXME - memory leak
     hclib_future_t **future_list = construct_future_list(futures...);
-    return forasync1D_future(loop, lambda, mode, place, future_list);
-}
-
-template <typename T>
-inline hclib::future_t *forasync2D_future(loop_domain_t* loop, T lambda,
-        int mode = FORASYNC_MODE_RECURSIVE, place_t *place = NULL,
-        hclib::future_t **future_list = NULL) {
-    hclib_start_finish();
-    forasync2D_internal<T>(loop, lambda, mode, place, future_list);
-    hclib::promise_t *event = new hclib::promise_t();
-    hclib_end_finish_nonblocking_helper(&event->internal);
-    return event->get_future();
-}
-
-template <typename T>
-inline hclib::future_t *forasync3D_future(loop_domain_t* loop, T lambda,
-        int mode = FORASYNC_MODE_RECURSIVE, place_t *place = NULL,
-        hclib::future_t **future_list = NULL) {
-    hclib_start_finish();
-    forasync3D_internal<T>(loop, lambda, mode, place, future_list);
-    hclib::promise_t *event = new hclib::promise_t();
-    hclib_end_finish_nonblocking_helper(&event->internal);
-    return event->get_future();
+    return forasync1D_future(loop, std::forward<decltype(lambda)>(lambda),
+            mode, place, future_list);
 }
 
 }

--- a/inc/hclib-rt.h
+++ b/inc/hclib-rt.h
@@ -79,6 +79,9 @@ typedef struct hclib_worker_state {
         LiteCtx *root_ctx;
 } hclib_worker_state;
 
+#define HCLIB_MACRO_CONCAT(x, y) _HCLIB_MACRO_CONCAT_IMPL(x, y)
+#define _HCLIB_MACRO_CONCAT_IMPL(x, y) x ## y
+
 #ifdef HC_ASSERTION_CHECK
 #define HASSERT(cond) { \
     if (!(cond)) { \
@@ -88,6 +91,17 @@ typedef struct hclib_worker_state {
 }
 #else
 #define HASSERT(cond)       // Do Nothing
+#endif
+
+#if defined(static_assert) || __cplusplus >= 201103L // defined in C11, C++11
+#define HASSERT_STATIC static_assert
+#elif __STDC_VERSION__ >= 201112L // C11
+#define HASSERT_STATIC _Static_assert
+#elif defined(__COUNTER__)
+#define HASSERT_STATIC(COND, MSG) \
+typedef int HCLIB_MACRO_CONCAT(_hc_static_assert, __COUNTER__)[(COND) ? 1 : -1]
+#elif defined(HC_ASSERTION_CHECK)
+#warning "Static assertions are not available"
 #endif
 
 #define CURRENT_WS_INTERNAL ((hclib_worker_state *) pthread_getspecific(ws_key))

--- a/inc/hclib.h
+++ b/inc/hclib.h
@@ -147,7 +147,7 @@ typedef void (*forasync3D_Fct_t)(void *arg, int index_outer, int index_mid,
  * @param[in] mode              Forasync mode to control chunking strategy (flat chunking or recursive).
  */
 void hclib_forasync(void *forasync_fct, void *argv,
-        hclib_future_t **future_list, int dim, loop_domain_t *domain,
+        hclib_future_t **future_list, int dim, const loop_domain_t *domain,
         forasync_mode_t mode);
 
 /*
@@ -155,7 +155,7 @@ void hclib_forasync(void *forasync_fct, void *argv,
  * triggered when all tasks belonging to this forasync have finished.
  */
 hclib_future_t *hclib_forasync_future(void *forasync_fct, void *argv,
-        hclib_future_t **future_list, int dim, loop_domain_t *domain,
+        hclib_future_t **future_list, int dim, const loop_domain_t *domain,
         forasync_mode_t mode);
 
 /**

--- a/inc/hclib.h
+++ b/inc/hclib.h
@@ -103,7 +103,8 @@ typedef int forasync_mode_t;
 /** @brief Forasync mode to perform static chunking of the iteration space. */
 #define FORASYNC_MODE_FLAT 0
 /** @brief To indicate an async need not register with any finish scopes. */
-#define ESCAPING_ASYNC      ((int) 0x2)
+#define ESCAPING_ASYNC ((int) 0x2)
+#define COMM_ASYNC     ((int) 0x4)
 
 /**
  * @brief Function prototype for a 1-dimension forasync.

--- a/inc/hclib_cpp.h
+++ b/inc/hclib_cpp.h
@@ -15,9 +15,8 @@ typedef place_t place_t;
 typedef place_type_t place_type_t;
 
 template <typename T>
-void launch(T lambda) {
-    hclib_task_t *user_task = _allocate_async(lambda, false);
-    hclib_launch((generic_frame_ptr)spawn, user_task);
+inline void launch(T &&lambda) {
+    hclib_launch(lambda_wrapper<T>, new T(lambda));
 }
 
 promise_t **promise_create_n(size_t nb_promises, int null_terminated);

--- a/inc/hclib_future.h
+++ b/inc/hclib_future.h
@@ -21,6 +21,11 @@ class future_t {
         }
 };
 
+// FIXME - we should be able to make future_t into a zero-overhead wrapper
+// around hclib_future_t, possibly via inheritance + static_cast
+//HASSERT_STATIC(std::is_pod<future_t>::value);
+//HASSERT_STATIC(sizeof(future_t) == sizeof(hclib_future_t));
+
 }
 
 #endif

--- a/inc/hclib_promise.h
+++ b/inc/hclib_promise.h
@@ -20,9 +20,13 @@ class promise_t {
         }
 
         future_t *get_future() {
+            // FIXME - memory leak!
             return new future_t(&internal.future);
         }
 };
+
+HASSERT_STATIC(sizeof(promise_t) == sizeof(hclib_promise_t),
+        "promise_t is a trivial wrapper around hclib_promise_t");
 
 }
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -4,7 +4,7 @@ SUBDIRS =
 INCLUDES_DIR = -I$(top_srcdir)/inc -I$(top_srcdir)/src/inc -I$(top_srcdir)/src/fcontext
 
 # cflags: important to define that otherwise we inherit default values too
-CFLAGS = -Wall -g -O3 -std=c99
+CFLAGS = -Wall -g -O3 -std=c11
 CXXFLAGS = -Wall -g -O3 -std=c++11
 LDFLAGS = -lpthread
 

--- a/src/hclib.c
+++ b/src/hclib.c
@@ -435,7 +435,8 @@ void forasync3D_flat(void *forasync_arg) {
 }
 
 static void forasync_internal(void *user_fct_ptr, void *user_arg,
-                              int dim, loop_domain_t *loop_domain, forasync_mode_t mode) {
+                              int dim, const loop_domain_t *loop_domain,
+                              forasync_mode_t mode) {
     // All the sub-asyncs share async_def
 
     // The user loop code to execute
@@ -469,7 +470,8 @@ static void forasync_internal(void *user_fct_ptr, void *user_arg,
 }
 
 void hclib_forasync(void *forasync_fct, void *argv,
-                    hclib_future_t **future_list, int dim, loop_domain_t *domain,
+                    hclib_future_t **future_list, int dim,
+                    const loop_domain_t *domain,
                     forasync_mode_t mode) {
     HASSERT(future_list == NULL &&
             "Limitation: forasync does not support futures yet");
@@ -478,7 +480,8 @@ void hclib_forasync(void *forasync_fct, void *argv,
 }
 
 hclib_future_t *hclib_forasync_future(void *forasync_fct, void *argv,
-                                      hclib_future_t **future_list, int dim, loop_domain_t *domain,
+                                      hclib_future_t **future_list, int dim,
+                                      const loop_domain_t *domain,
                                       forasync_mode_t mode) {
 
     hclib_start_finish();

--- a/test/c/.gitignore
+++ b/test/c/.gitignore
@@ -1,3 +1,4 @@
+targets.txt
 *.dSYM
 async0
 async1

--- a/test/c/Makefile
+++ b/test/c/Makefile
@@ -7,7 +7,11 @@ TARGETS=async0 async1 finish0 finish1 finish2  forasync1DCh  forasync1DRec \
 
 FLAGS=-g
 
-all: $(TARGETS)
+all: $(TARGETS) targets.txt
+
+.PHONY: targets.txt # always update
+targets.txt:
+	@echo "$(TARGETS)" > $@
 
 %: %.c
 	gcc ${FLAGS} $(PROJECT_CFLAGS) $(PROJECT_LDFLAGS) -o $@ $^ $(PROJECT_LDLIBS)

--- a/test/c/promise/future1.c
+++ b/test/c/promise/future1.c
@@ -18,7 +18,7 @@ void producer(void *arg) {
     assert(signal);
     *signal = 42;
 
-    sleep(5);
+    sleep(1);
 
     hclib_promise_put(event, signal);
 }

--- a/test/c/promise/future2.c
+++ b/test/c/promise/future2.c
@@ -46,7 +46,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 void forasync_fct1(void *argv, int idx) {
     int *ran = (int *)argv;
 
-    sleep(1);
+    usleep(100000);
 
     assert(ran[idx] == -1);
     ran[idx] = idx;

--- a/test/c/promise/future3.c
+++ b/test/c/promise/future3.c
@@ -46,7 +46,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 void forasync_fct1(void *argv, int idx) {
     int *ran = (int *)argv;
 
-    sleep(1);
+    usleep(100000);
 
     assert(ran[idx] == -1);
     ran[idx] = idx;

--- a/test/c/test_all.sh
+++ b/test/c/test_all.sh
@@ -5,10 +5,9 @@ set -e
 make clean
 make -j
 
-for f in $(find . -name "*"); do
-    if [[ -x $f && ! -d $f && $(basename $f) != 'test_all.sh' ]]; then
-        echo "========== Running $f =========="
-        $f
-        echo
-    fi
+for f in `cat targets.txt`; do
+    [[ -x $f && ! -d $f ]]
+    echo "========== Running $f =========="
+    ./$f
+    echo
 done

--- a/test/cpp/.gitignore
+++ b/test/cpp/.gitignore
@@ -1,3 +1,4 @@
+targets.txt
 *.dSYM
 async0
 async1

--- a/test/cpp/.gitignore
+++ b/test/cpp/.gitignore
@@ -19,4 +19,5 @@ forasync3DCh
 forasync3DRec
 neconlce1
 access_argc
-capture[0-9]
+capture?
+copies?

--- a/test/cpp/Makefile
+++ b/test/cpp/Makefile
@@ -4,7 +4,7 @@ TARGETS=async0 async1 finish0 finish1 finish2  forasync1DCh  forasync1DRec \
 		forasync2DCh  forasync2DRec  forasync3DCh  forasync3DRec \
 		promise/asyncAwait0 promise/asyncAwait0Null promise/asyncAwait1 promise/future0 \
 		promise/future1 promise/future2 promise/future3 neconlce1 access_argc \
-		capture0 capture1
+		capture0 capture1 copies0 copies1
 
 FLAGS=-g -std=c++11
 

--- a/test/cpp/Makefile
+++ b/test/cpp/Makefile
@@ -8,7 +8,11 @@ TARGETS=async0 async1 finish0 finish1 finish2  forasync1DCh  forasync1DRec \
 
 FLAGS=-g -std=c++11
 
-all: $(TARGETS)
+all: $(TARGETS) targets.txt
+
+.PHONY: targets.txt # always update
+targets.txt:
+	@echo "$(TARGETS)" > $@
 
 %: %.cpp
 	g++ ${FLAGS} $(PROJECT_CFLAGS) $(PROJECT_LDFLAGS) -o $@ $^ $(PROJECT_LDLIBS)

--- a/test/cpp/capture0.cpp
+++ b/test/cpp/capture0.cpp
@@ -51,7 +51,7 @@ int main (int argc, char ** argv) {
             auto p = std::make_shared<SimpleObject>();
             std::cout << "Value starts as " << p->value << std::endl;
             hclib::async([=](){
-                usleep(100);
+                usleep(100000);
                 std::cout << "Value in async is " << p->value << std::endl;
                 assert(p->value == 1);
             });

--- a/test/cpp/copies0.cpp
+++ b/test/cpp/copies0.cpp
@@ -61,7 +61,7 @@ int main (int argc, char ** argv) {
                 printf("Counted %d copies, %d moves...\n", k.copies, k.moves);
                 // Copy 1: capturing "k" by-value into the lambda
                 // Copy 2: copying the lambda (and its closure) into the heap
-                //assert(k.copies + k.moves <= 2);
+                assert(k.copies + k.moves <= 2);
             });
         });
     });

--- a/test/cpp/copies0.cpp
+++ b/test/cpp/copies0.cpp
@@ -1,0 +1,70 @@
+/* Copyright (c) 2013, Rice University
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+1.  Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+2.  Redistributions in binary form must reproduce the above
+     copyright notice, this list of conditions and the following
+     disclaimer in the documentation and/or other materials provided
+     with the distribution.
+3.  Neither the name of Rice University
+     nor the names of its contributors may be used to endorse or
+     promote products derived from this software without specific
+     prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+/**
+ * DESC: Counting lambda copies for a simple async
+ */
+#include <stdlib.h>
+#include <stdio.h>
+#include <assert.h>
+
+#include "hclib_cpp.h"
+
+struct CopyCounter {
+    int copies;
+    int moves;
+
+    CopyCounter(): copies(0), moves(0) {
+        printf("Created new counter object.\n");
+    }
+
+    CopyCounter(const CopyCounter &other):
+        copies(other.copies+1), moves(other.moves) { }
+
+    CopyCounter(const CopyCounter &&other):
+        copies(other.copies), moves(other.moves+1) { }
+};
+
+int main (int argc, char ** argv) {
+    hclib::launch([]() {
+        hclib::finish([]() {
+            CopyCounter k {};
+            hclib::async([k] {
+                printf("Counted %d copies, %d moves...\n", k.copies, k.moves);
+                // Copy 1: capturing "k" by-value into the lambda
+                // Copy 2: copying the lambda (and its closure) into the heap
+                //assert(k.copies + k.moves <= 2);
+            });
+        });
+    });
+    printf("Exiting...\n");
+    return 0;
+}

--- a/test/cpp/copies1.cpp
+++ b/test/cpp/copies1.cpp
@@ -110,7 +110,7 @@ int main (int argc, char ** argv) {
     free(ran);
     printf("Counted %d copies, %d moves...\n",
             int(globalCopies), int(globalMoves));
-    //assert(globalCopies + globalMoves <= 2);
+    assert(globalCopies + globalMoves <= 2);
     printf("OK\n");
     return 0;
 }

--- a/test/cpp/copies1.cpp
+++ b/test/cpp/copies1.cpp
@@ -1,0 +1,116 @@
+/* Copyright (c) 2013, Rice University
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+1.  Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+2.  Redistributions in binary form must reproduce the above
+     copyright notice, this list of conditions and the following
+     disclaimer in the documentation and/or other materials provided
+     with the distribution.
+3.  Neither the name of Rice University
+     nor the names of its contributors may be used to endorse or
+     promote products derived from this software without specific
+     prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+ */
+
+/**
+ * DESC: Counting lambda copies when using forasync
+ */
+#include <stdlib.h>
+#include <stdio.h>
+#include <assert.h>
+
+#include "hclib_cpp.h"
+
+#define H3 1024
+#define H2 512
+#define H1 16
+#define T3 33
+#define T2 217
+#define T1 7
+
+void init_ran(int *ran, int size) {
+    while (size > 0) {
+        ran[size-1] = -1;
+        size--;
+    }
+}
+
+#include <atomic>
+std::atomic<int> globalCopies;
+std::atomic<int> globalMoves;
+
+struct CopyCounter {
+    int copies;
+    int moves;
+
+    CopyCounter(): copies(0), moves(0) {
+        printf("Created new counter object.\n");
+    }
+
+    CopyCounter(const CopyCounter &other):
+        copies(other.copies+1), moves(other.moves) {
+            globalCopies++;
+        }
+
+    CopyCounter(const CopyCounter &&other):
+        copies(other.copies), moves(other.moves+1) {
+            globalMoves++;
+        }
+};
+
+
+
+int main (int argc, char ** argv) {
+    printf("Call Init\n");
+    int *ran=(int *)malloc(H1*H2*H3*sizeof(int));
+
+    hclib::launch([=]() {
+        int i = 0;
+        // This is ok to have these on stack because this
+        // code is alive until the end of the program.
+
+        init_ran(ran, H1*H2*H3);
+        hclib::finish([=]() {
+            CopyCounter k {};
+            loop_domain_t loop0 = {0,H1,1,T1};
+            loop_domain_t loop1 = {0,H2,1,T2};
+            loop_domain_t loop2 = {0,H3,1,T3};
+            loop_domain_t loop[3] = {loop0, loop1, loop2};
+            hclib::forasync3D(loop, [=](int idx1, int idx2, int idx3) {
+                    (void)k;
+                    assert(ran[idx1*H2*H3+idx2*H3+idx3] == -1);
+                    ran[idx1*H2*H3+idx2*H3+idx3] = idx1*H2*H3+idx2*H3+idx3; },
+                    FORASYNC_MODE_RECURSIVE);
+        });
+    });
+
+    printf("Check results: ");
+    int i = 0;
+    while(i < H1*H2*H3) {
+        assert(ran[i] == i);
+        i++;
+    }
+    free(ran);
+    printf("Counted %d copies, %d moves...\n",
+            int(globalCopies), int(globalMoves));
+    //assert(globalCopies + globalMoves <= 2);
+    printf("OK\n");
+    return 0;
+}

--- a/test/cpp/promise/future1.cpp
+++ b/test/cpp/promise/future1.cpp
@@ -26,7 +26,7 @@ int main(int argc, char ** argv) {
                     assert(signal);
                     *signal = 42;
 
-                    sleep(5);
+                    sleep(1);
                     event->put(signal);
                 });
         });

--- a/test/cpp/promise/future2.cpp
+++ b/test/cpp/promise/future2.cpp
@@ -64,7 +64,7 @@ int main (int argc, char ** argv) {
             hclib::future_t *event = hclib::nonblocking_finish([=]() {
                 loop_domain_t loop = {0, H1, 1, T1};
                 hclib::forasync1D(&loop, [=](int idx) {
-                        sleep(1);
+                        usleep(100000);
                         assert(ran[idx] == -1);
                         ran[idx] = idx;
                         printf("finished %d / %d\n", idx, H1);

--- a/test/cpp/promise/future3.cpp
+++ b/test/cpp/promise/future3.cpp
@@ -65,7 +65,7 @@ int main (int argc, char ** argv) {
 
             hclib::future_t *event = hclib::forasync1D_future(&loop,
                     [=](int idx) {
-                        sleep(1);
+                        usleep(100000);
                         assert(ran[idx] == -1);
                         ran[idx] = idx;
                         printf("finished %d / %d\n", idx, H1);

--- a/test/cpp/test_all.sh
+++ b/test/cpp/test_all.sh
@@ -5,10 +5,9 @@ set -e
 make clean
 make -j
 
-for f in $(find . -name "*"); do
-    if [[ -x $f && ! -d $f && $(basename $f) != 'test_all.sh' ]]; then
-        echo "========== Running $f =========="
-        $f
-        echo
-    fi
+for f in `cat targets.txt`; do
+    [[ -x $f && ! -d $f ]]
+    echo "========== Running $f =========="
+    ./$f
+    echo
 done


### PR DESCRIPTION
My understanding was that we wanted the C++ API to be a thin wrapper over the C API. These changes update the C++ API for async, forasync, etc. so that most of the internal logic is delegated to the C code.

This patch should also close issue #17, since it eliminates most of the extra copies of user functors that were happening in the C++ code in the async implementation, and more especially in forasync implementation.

---

<i>Note: This pull request builds on #16. You can compare the branches corresponding to the pull requests to see the diff between just #16 and this PR: https://github.com/habanero-rice/hclib/compare/cxx-cleanup-4...cxx-cleanup-5</i>
