### PR TITLE
Feature/C11 atomics

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 # Use Ubuntu 14.04 Trusty for GCC 4.8
-sudo: required
 dist: trusty
+sudo: required
 language: cpp
 
 branches:
@@ -9,10 +9,33 @@ branches:
 
 matrix:
   include:
-  - compiler: gcc
-  - compiler: clang
+  - compiler: gcc # gcc-4.8
+  - env: TRAVIS_CC=gcc-5 TRAVIS_CXX=g++-5
+    addons:
+      apt:
+        packages:
+          - g++-5
+        sources:
+          - ubuntu-toolchain-r-test
+  - env: TRAVIS_CC=gcc-6 TRAVIS_CXX=g++-6
+    addons:
+      apt:
+        packages:
+          - g++-6
+        sources:
+          - ubuntu-toolchain-r-test
+  - compiler: clang # clang-3.5
+  - env: TRAVIS_CC=clang-4.0 TRAVIS_CXX=clang++-4.0
+    addons:
+      apt:
+        packages:
+          - clang-4.0
+        sources:
+          - llvm-toolchain-trusty-4.0
 
 before_install:
+- export CC=${TRAVIS_CC:-$CC} && $CC --version
+- export CXX=${TRAVIS_CXX:-$CXX} && $CXX --version
 - sudo apt-get update -qq
 - sudo apt-get install -y libxml2-dev
 

--- a/configure.ac
+++ b/configure.ac
@@ -133,9 +133,41 @@ AS_IF([test "x$with_production" != xno],
 AM_CONDITIONAL(PRODUCTION_SETTINGS, test "x$with_production" != xno)
 ### End PRODUCTION settings
 
+### C11 features check
+AC_LANG_PUSH(C)
+_old_CFLAGS="${CFLAGS}"
+CFLAGS="${_old_CFLAGS} -std=c11"
+# We require basic C11 support
+AC_CACHE_CHECK([for basic C11 support], [ac_cv_c11_lang],
+[AC_COMPILE_IFELSE([AC_LANG_PROGRAM([], [])],
+                   [ac_cv_c11_lang=yes],
+                   [ac_cv_c11_lang=no])])
+if test $ac_cv_c11_lang = no; then
+    AC_MSG_ERROR(C11 support (-std=c11) is requred)
+fi
+# NOTE: Sadly, we can't trust __STDC_NO_ATOMICS__
+AC_CACHE_CHECK([for C11 stdatomic.h support], [ac_cv_c11_stdatomic],
+[AC_COMPILE_IFELSE([AC_LANG_PROGRAM([#include  <stdatomic.h>], [])],
+                   [ac_cv_c11_stdatomic=yes],
+                   [ac_cv_c11_stdatomic=no])])
+if test $ac_cv_c11_stdatomic = yes; then
+    AC_DEFINE([HAVE_C11_STDATOMIC], [1], [Defined if C11 stdatomic.h is available.])
+fi
+CFLAGS="${_old_CFLAGS}"
+AC_LANG_POP(C)
+### End C11 features check
+
 ### C++11 features check
 _old_CXXFLAGS="${CXXFLAGS}"
 CXXFLAGS="${_old_CXXFLAGS} -std=c++11"
+# We require basic C++11 support
+AC_CACHE_CHECK([for basic C++11 support], [ac_cv_cxx11_lang],
+[AC_COMPILE_IFELSE([AC_LANG_PROGRAM([], [])],
+                   [ac_cv_cxx11_lang=yes],
+                   [ac_cv_cxx11_lang=no])])
+if test $ac_cv_cxx11_lang = no; then
+    AC_MSG_ERROR(C++11 support (-std=c++11) is requred)
+fi
 AC_CACHE_CHECK([for C++11 std::is_trivially_copyable support], [ac_cv_cxx11_trivial_copy_check],
 [AC_COMPILE_IFELSE([AC_LANG_PROGRAM([#include  <type_traits>], [return std::is_trivially_copyable<int>::value;])],
                    [ac_cv_cxx11_trivial_copy_check=yes],

--- a/inc/hclib_config.h.in
+++ b/inc/hclib_config.h.in
@@ -1,6 +1,9 @@
 #ifndef HCLIB_CONFIG_H_
 #define HCLIB_CONFIG_H_
 
+/* Defined if C11 stdatomic.h is available. */
+#undef HAVE_C11_STDATOMIC
+
 /* Defined if C++11 std::is_trivially_copyable is supported. */
 #undef HAVE_CXX11_TRIVIAL_COPY_CHECK
 

--- a/src/hclib-deque.c
+++ b/src/hclib-deque.c
@@ -39,30 +39,36 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "hclib-internal.h"
 #include "hclib-atomics.h"
 
-void deque_init(deque_t *deq, void *init_value) {
+#if 0 // UNUSED
+void deque_init(deque_t *deq) {
     deq->head = 0;
+    //@ FIXME ATOMIC: this should be a RELEASE to ensure synchronization?
     deq->tail = 0;
 }
+
+void deque_destroy(deque_t *deq) {
+    free(deq);
+}
+#endif
 
 /*
  * push an entry onto the tail of the deque
  */
-int deque_push(deque_t *deq, void *entry) {
-    int size = deq->tail - deq->head;
+int deque_push(deque_t *deq, hclib_task_t *entry) {
+    int tail = _hclib_atomic_load_relaxed(&deq->tail);
+    int head = _hclib_atomic_load_relaxed(&deq->head);
+    int size = tail - head;
     if (size == INIT_DEQUE_CAPACITY) { /* deque looks full */
         /* may not grow the deque if some interleaving steal occur */
         // std::cout<<getenv("PMI_RANK") <<": Deque full for worker-"<<current_ws()->id << std::endl;
         // HASSERT("DEQUE full, increase deque's size " && 0);
         return 0;
     }
-    int n = (deq->tail) % INIT_DEQUE_CAPACITY;
-    deq->data[n] = (hclib_task_t *) entry;
-    deq->tail++;
+    int n = tail % INIT_DEQUE_CAPACITY;
+    deq->data[n] = entry;
+    //@ ATOMIC: this should be a RELEASE to ensure synchronization
+    _hclib_atomic_inc_release(&deq->tail);
     return 1;
-}
-
-void deque_destroy(deque_t *deq) {
-    free(deq);
 }
 
 /*
@@ -78,16 +84,18 @@ hclib_task_t *deque_steal(deque_t *deq) {
      */
     int tail;
 
-    head = deq->head;
-    hc_mfence();
-    tail = deq->tail;
+    head = _hclib_atomic_load_relaxed(&deq->head);
+    // ATOMIC: load acquire
+    // We want all the writes from the producing thread to read the task data
+    // and we're using the tail as the synchronization variable
+    tail = _hclib_atomic_load_acquire(&deq->tail);
     if ((tail - head) <= 0) {
         return NULL;
     }
 
-    hclib_task_t *t = (hclib_task_t *) deq->data[head % INIT_DEQUE_CAPACITY];
+    hclib_task_t *t = deq->data[head % INIT_DEQUE_CAPACITY];
     /* compete with other thieves and possibly the owner (if the size == 1) */
-    if (hc_cas(&deq->head, head, head + 1)) { /* competing */
+    if (_hclib_atomic_cas_acq_rel(&deq->head, head, head + 1)) { /* competing */
         return t;
     }
     return NULL;
@@ -97,31 +105,29 @@ hclib_task_t *deque_steal(deque_t *deq) {
  * pop the task out of the deque from the tail
  */
 hclib_task_t *deque_pop(deque_t *deq) {
-    hc_mfence();
-    int tail = deq->tail;
-    tail--;
-    deq->tail = tail;
-    hc_mfence();
-    int head = deq->head;
+    int tail = _hclib_atomic_dec_relaxed(&deq->tail);
+    int head = _hclib_atomic_load_relaxed(&deq->head);
 
     int size = tail - head;
     if (size < 0) {
-        deq->tail = deq->head;
+        _hclib_atomic_store_relaxed(&deq->tail, head);
         return NULL;
     }
-    hclib_task_t *t = (hclib_task_t *) deq->data[(tail) % INIT_DEQUE_CAPACITY];
+    hclib_task_t *t = deq->data[tail % INIT_DEQUE_CAPACITY];
 
     if (size > 0) {
         return t;
     }
 
-    /* now size == 1, I need to compete with the thieves */
-    if (!hc_cas(&deq->head, head, head + 1)) {
+    /* now the deque appears empty */
+    /* I need to compete with the thieves for the last task */
+    //@- if (!hc_cas(&deq->head, head, head + 1)) {
+    if (!_hclib_atomic_cas_acq_rel(&deq->head, head, head + 1)) {
         t = NULL;
     }
 
-    /* now the deque is empty */
-    deq->tail = deq->head;
+    _hclib_atomic_inc_relaxed(&deq->tail);
+
     return t;
 }
 
@@ -129,7 +135,8 @@ hclib_task_t *deque_pop(deque_t *deq) {
 /* Semi Concurrent DEQUE                              */
 /******************************************************/
 
-void semi_conc_deque_init(semi_conc_deque_t *semiDeq, void *initValue) {
+#if 0 // UNUSED
+void semi_conc_deque_init(semi_conc_deque_t *semiDeq) {
     deque_t *deq = &semiDeq->deque;
     deq->head = 0;
     deq->tail = 0;
@@ -140,7 +147,7 @@ void semi_conc_deque_destroy(semi_conc_deque_t *semiDeq) {
     free(semiDeq);
 }
 
-void semi_conc_deque_locked_push(semi_conc_deque_t *semiDeq, void *entry) {
+void semi_conc_deque_locked_push(semi_conc_deque_t *semiDeq, hclib_task_t *entry) {
     deque_t *deq = &semiDeq->deque;
     int success = 0;
     while (!success) {
@@ -172,5 +179,6 @@ hclib_task_t *semi_conc_deque_non_locked_pop(semi_conc_deque_t *semiDeq) {
     }
     return NULL;
 }
+#endif
 
 

--- a/src/hclib-deque.c
+++ b/src/hclib-deque.c
@@ -39,18 +39,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "hclib-internal.h"
 #include "hclib-atomics.h"
 
-#if 0 // UNUSED
-void deque_init(deque_t *deq) {
-    deq->head = 0;
-    //@ FIXME ATOMIC: this should be a RELEASE to ensure synchronization?
-    deq->tail = 0;
-}
-
-void deque_destroy(deque_t *deq) {
-    free(deq);
-}
-#endif
-
 /*
  * push an entry onto the tail of the deque
  */
@@ -130,55 +118,4 @@ hclib_task_t *deque_pop(deque_t *deq) {
 
     return t;
 }
-
-/******************************************************/
-/* Semi Concurrent DEQUE                              */
-/******************************************************/
-
-#if 0 // UNUSED
-void semi_conc_deque_init(semi_conc_deque_t *semiDeq) {
-    deque_t *deq = &semiDeq->deque;
-    deq->head = 0;
-    deq->tail = 0;
-    semiDeq->lock = 0;
-}
-
-void semi_conc_deque_destroy(semi_conc_deque_t *semiDeq) {
-    free(semiDeq);
-}
-
-void semi_conc_deque_locked_push(semi_conc_deque_t *semiDeq, hclib_task_t *entry) {
-    deque_t *deq = &semiDeq->deque;
-    int success = 0;
-    while (!success) {
-        int size = deq->tail - deq->head;
-        if (INIT_DEQUE_CAPACITY == size) {
-            HASSERT("DEQUE full, increase deque's size" && 0);
-        }
-
-        if (hc_cas(&semiDeq->lock, 0, 1) ) {
-            success = 1;
-            int n = deq->tail % INIT_DEQUE_CAPACITY;
-            deq->data[n] = (hclib_task_t *) entry;
-            hc_mfence();
-            ++deq->tail;
-            semiDeq->lock= 0;
-        }
-    }
-}
-
-hclib_task_t *semi_conc_deque_non_locked_pop(semi_conc_deque_t *semiDeq) {
-    deque_t *deq = &semiDeq->deque;
-    int head = deq->head;
-    int tail = deq->tail;
-
-    if ((tail - head) > 0) {
-        hclib_task_t *t = (hclib_task_t *) deq->data[head % INIT_DEQUE_CAPACITY];
-        ++deq->head;
-        return t;
-    }
-    return NULL;
-}
-#endif
-
 

--- a/src/hclib-hpt.c
+++ b/src/hclib-hpt.c
@@ -283,7 +283,7 @@ hc_deque_t *get_deque_hpt(hclib_worker_state *ws, place_t *pl) {
 
 }
 
-int deque_push_place(hclib_worker_state *ws, place_t *pl, void *ele) {
+int deque_push_place(hclib_worker_state *ws, place_t *pl, hclib_task_t *ele) {
     hc_deque_t *deq = get_deque_place(ws, pl);
     return deque_push(&deq->deque, ele);
 }

--- a/src/hclib-runtime.c
+++ b/src/hclib-runtime.c
@@ -346,14 +346,15 @@ void hclib_cleanup() {
 
 static inline void check_in_finish(finish_t *finish) {
     if (finish) {
-        hc_atomic_inc(&(finish->counter));
+        // FIXME - does this need to be acquire, or can it be relaxed?
+        _hclib_atomic_inc_acquire(&finish->counter);
     }
 }
 
 static inline void check_out_finish(finish_t *finish) {
     if (finish) {
-        // hc_atomic_dec returns true when finish->counter goes to zero
-        if (hc_atomic_dec(&(finish->counter))) {
+        // was this the last async to check out?
+        if (_hclib_atomic_dec_release(&finish->counter) == 0) {
 #if HCLIB_LITECTX_STRATEGY
             HASSERT(!_hclib_promise_is_satisfied(finish->finish_deps[0]->owner));
             hclib_promise_put(finish->finish_deps[0]->owner, finish);
@@ -994,11 +995,11 @@ static inline void slave_worker_finishHelper_routine(finish_t *finish) {
     const int wid = ws->id;
 #endif
 
-    while (finish->counter > 0) {
+    while (_hclib_atomic_load_relaxed(&finish->counter) > 0) {
         // try to pop
         hclib_task_t *task = hpt_pop_task(ws);
         if (!task) {
-            while (finish->counter > 0) {
+            while (_hclib_atomic_load_relaxed(&finish->counter) > 0) {
                 // try to steal
                 task = hpt_steal_task(ws);
                 if (task) {
@@ -1030,7 +1031,8 @@ static void _help_finish(finish_t *finish) {
 #endif
     slave_worker_finishHelper_routine(finish);
 }
-#endif /* HCLIB_LITECTX_STRATEGY */
+
+#endif /* HCLIB_???_STRATEGY */
 
 void help_finish(finish_t *finish) {
     // This is called to make progress when an end_finish has been
@@ -1073,12 +1075,12 @@ void help_finish(finish_t *finish) {
                 deque_push_place(ws, NULL, task);
                 break;
             }
-        } while (finish->counter > 1);
+        } while (_hclib_atomic_load_relaxed(&finish->counter) > 1);
 
         // Someone stole our last task...
         // Create a new context to do other work,
         // and suspend this finish scope pending on the outstanding tasks.
-        if (finish->counter > 1) {
+        if (_hclib_atomic_load_relaxed(&finish->counter) > 1) {
             // create finish event
             hclib_promise_t *finish_promise = hclib_promise_create();
             hclib_future_t *finish_deps[] = { &finish_promise->future, NULL };
@@ -1094,22 +1096,25 @@ void help_finish(finish_t *finish) {
 #endif
             ctx_swap(currentCtx, newCtx, __func__);
 
+            // note: the other context checks out of the current finish scope
+
             // destroy the context that resumed this one since it's now defunct
             // (there are no other handles to it, and it will never be resumed)
             LiteCtx_destroy(currentCtx->prev);
             hclib_promise_free(finish_promise);
         } else {
-            HASSERT(finish->counter == 1);
+            HASSERT(_hclib_atomic_load_relaxed(&finish->counter) == 1);
             // finish->counter == 1 implies that all the tasks are done
             // (it's only waiting on itself now), so just return!
-            --finish->counter;
+            _hclib_atomic_dec_acq_rel(&finish->counter);
         }
     }
 #else /* default (broken) strategy */
+    // FIXME - do I need to decrement the finish counter here?
     _help_finish(finish);
 #endif /* HCLIB_???_STRATEGY */
 
-    HASSERT(finish->counter == 0);
+    HASSERT(_hclib_atomic_load_relaxed(&finish->counter) == 0);
 
 }
 
@@ -1133,21 +1138,21 @@ void hclib_start_finish() {
      * This would make it harder to detect when all tasks within the finish have
      * completed, or just the tasks launched so far.
      */
-    finish->counter = 1;
     finish->parent = ws->current_finish;
 #if HCLIB_LITECTX_STRATEGY
     finish->finish_deps = NULL;
 #endif
     check_in_finish(finish->parent); // check_in_finish performs NULL check
     ws->current_finish = finish;
+    _hclib_atomic_store_release(&finish->counter, 1);
 }
 
 void hclib_end_finish() {
     finish_t *current_finish = CURRENT_WS_INTERNAL->current_finish;
 
-    HASSERT(current_finish->counter > 0);
+    HASSERT(_hclib_atomic_load_relaxed(&current_finish->counter) > 0);
     help_finish(current_finish);
-    HASSERT(current_finish->counter == 0);
+    HASSERT(_hclib_atomic_load_relaxed(&current_finish->counter) == 0);
 
     check_out_finish(current_finish->parent); // NULL check in check_out_finish
 
@@ -1160,7 +1165,7 @@ void hclib_end_finish() {
 void hclib_end_finish_nonblocking_helper(hclib_promise_t *event) {
     finish_t *current_finish = CURRENT_WS_INTERNAL->current_finish;
 
-    HASSERT(current_finish->counter > 0);
+    HASSERT(_hclib_atomic_load_relaxed(&current_finish->counter) > 0);
 
     // NOTE: this is a nasty hack to avoid a memory leak here.
     // Previously we were allocating a two-element array of

--- a/src/inc/hclib-deque.h
+++ b/src/inc/hclib-deque.h
@@ -54,23 +54,8 @@ typedef struct deque_t {
     hclib_task_t* data[INIT_DEQUE_CAPACITY];
 } deque_t;
 
-void deque_init(deque_t *deq);
 int deque_push(deque_t *deq, hclib_task_t *entry);
 hclib_task_t* deque_pop(deque_t *deq);
 hclib_task_t* deque_steal(deque_t *deq);
-void deque_destroy(deque_t *deq);
-
-/****************************************************/
-/* Semi Concurrent DEQUE API                        */
-/****************************************************/
-typedef struct {
-    deque_t deque;
-    _Atomic int lock;
-} semi_conc_deque_t;
-
-void semi_conc_deque_init(semi_conc_deque_t* deq);
-void semi_conc_deque_locked_push(semi_conc_deque_t* deq, hclib_task_t* entry);
-hclib_task_t* semi_conc_deque_non_locked_pop(semi_conc_deque_t * deq);
-void semi_conc_deque_destroy(semi_conc_deque_t * deq);
 
 #endif /* HCLIB_DEQUE_H_ */

--- a/src/inc/hclib-deque.h
+++ b/src/inc/hclib-deque.h
@@ -40,6 +40,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define HCLIB_DEQUE_H_
 
 #include "hclib-task.h"
+#include "hclib-atomics.h"
 
 /****************************************************/
 /* DEQUE API                                        */
@@ -48,13 +49,13 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define INIT_DEQUE_CAPACITY 8096
 
 typedef struct deque_t {
-    volatile int head;
-    volatile int tail;
-    volatile hclib_task_t* data[INIT_DEQUE_CAPACITY];
+    _Atomic int head;
+    _Atomic int tail;
+    hclib_task_t* data[INIT_DEQUE_CAPACITY];
 } deque_t;
 
-void deque_init(deque_t *deq, void *initValue);
-int deque_push(deque_t *deq, void *entry);
+void deque_init(deque_t *deq);
+int deque_push(deque_t *deq, hclib_task_t *entry);
 hclib_task_t* deque_pop(deque_t *deq);
 hclib_task_t* deque_steal(deque_t *deq);
 void deque_destroy(deque_t *deq);
@@ -64,11 +65,11 @@ void deque_destroy(deque_t *deq);
 /****************************************************/
 typedef struct {
     deque_t deque;
-    volatile int lock;
+    _Atomic int lock;
 } semi_conc_deque_t;
 
-void semi_conc_deque_init(semi_conc_deque_t* deq, void * initValue);
-void semi_conc_deque_locked_push(semi_conc_deque_t* deq, void* entry);
+void semi_conc_deque_init(semi_conc_deque_t* deq);
+void semi_conc_deque_locked_push(semi_conc_deque_t* deq, hclib_task_t* entry);
 hclib_task_t* semi_conc_deque_non_locked_pop(semi_conc_deque_t * deq);
 void semi_conc_deque_destroy(semi_conc_deque_t * deq);
 

--- a/src/inc/hclib-finish.h
+++ b/src/inc/hclib-finish.h
@@ -2,10 +2,11 @@
 #define HCLIB_FINISH_H
 
 #include "hclib-promise.h"
+#include "hclib-atomics.h"
 
 typedef struct finish_t {
     struct finish_t* parent;
-    volatile int counter;
+    _Atomic int counter;
 #if HCLIB_LITECTX_STRATEGY
     hclib_future_t ** finish_deps;
 #endif /* HCLIB_LITECTX_STRATEGY */

--- a/src/inc/hclib-hpt.h
+++ b/src/inc/hclib-hpt.h
@@ -52,6 +52,6 @@ void hc_hpt_dev_cleanup(hc_context * context);
 hc_deque_t * get_deque_place(hclib_worker_state * ws, place_t * pl);
 hclib_task_t* hpt_pop_task(hclib_worker_state * ws);
 hclib_task_t* hpt_steal_task(hclib_worker_state* ws);
-int deque_push_place(hclib_worker_state *ws, place_t * pl, void * ele);
+int deque_push_place(hclib_worker_state *ws, place_t * pl, hclib_task_t * ele);
 
 #endif /* HCLIB_HPT_H_ */

--- a/src/inc/hclib-internal.h
+++ b/src/inc/hclib-internal.h
@@ -41,6 +41,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <stdarg.h>
 #include <stdint.h>
+#include "hclib_config.h"
 #include "hclib-tree.h"
 #include "hclib-deque.h"
 #include "hclib.h"


### PR DESCRIPTION
Use the standard, portable C11 stdatomic.h for the atomic operations internal to HClib rather than the platform-specific assembly code in our current version. This was tested against a subset of [Max's tasking micro benchmarks](https://github.com/habanero-rice/tasking-micro-benchmark-suite), and there was no measurable difference in performance on x86_64 (guad.cs.rice.edu) or Power7 (biou.rice.edu).