### PR TITLE
Add -std=c11 flag to default project CFLAGS

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Dependencies
 
 * automake
 * gcc >= 4.8.4, or clang >= 3.5
-  (must support -std=c++11)
+  (must support -std=c11 and -std=c++11)
 * libxml2 (with development headers)
 
 

--- a/inc/hclib-mak/hclib.mak
+++ b/inc/hclib-mak/hclib.mak
@@ -2,10 +2,11 @@ ifeq ("$(HCLIB_ROOT)", "")
   $(error Please set teh HCLIB_ROOT environment variable.)
 endif
 
-PROJECT_CFLAGS=-I$(HCLIB_ROOT)/include $(shell xml2-config --cflags)
-PROJECT_CXXFLAGS=-std=c++11 $(PROJECT_CFLAGS)
-PROJECT_LDFLAGS=-L$(HCLIB_ROOT)/lib
-PROJECT_LDLIBS=-lhclib -Wl,-rpath,$(HCLIB_ROOT)/lib $(shell xml2-config --libs)
+PROJECT_BASE_FLAGS := -I$(HCLIB_ROOT)/include $(shell xml2-config --cflags)
+PROJECT_CFLAGS     := -std=c11 $(PROJECT_BASE_FLAGS)
+PROJECT_CXXFLAGS   := -std=c++11 $(PROJECT_BASE_FLAGS)
+PROJECT_LDFLAGS    := -L$(HCLIB_ROOT)/lib
+PROJECT_LDLIBS     := -lhclib -Wl,-rpath,$(HCLIB_ROOT)/lib $(shell xml2-config --libs)
 ifdef TBB_MALLOC
   PROJECT_LDFLAGS+=-L$(TBB_MALLOC)
   PROJECT_LDLIBS+=-ltbbmalloc_proxy

--- a/test/cpp/Makefile
+++ b/test/cpp/Makefile
@@ -18,7 +18,7 @@ targets.txt:
 	@echo "$(TARGETS)" > $@
 
 %: %.cpp
-	$(CXX) ${FLAGS} $(PROJECT_CFLAGS) $(PROJECT_LDFLAGS) -o $@ $^ $(PROJECT_LDLIBS)
+	$(CXX) ${FLAGS} $(PROJECT_CXXFLAGS) $(PROJECT_LDFLAGS) -o $@ $^ $(PROJECT_LDLIBS)
 
 clean:
 	rm -f $(TARGETS)


### PR DESCRIPTION
Needed for variadic macros and other more modern C features.
Tests using `HCLIB_FINISH` don't compile on legacy compilers without this.
Newer compilers have these features enabled by default,
but legacy compilers (e.g., gcc 4.8) need an explicit flag.