### PR TITLE
Only set HAVE_C11_STDATOMIC if we have the _Atomic keyword

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -133,7 +133,7 @@ if test $ac_cv_c11_lang = no; then
 fi
 # NOTE: Sadly, we can't trust __STDC_NO_ATOMICS__
 AC_CACHE_CHECK([for C11 stdatomic.h support], [ac_cv_c11_stdatomic],
-[AC_COMPILE_IFELSE([AC_LANG_PROGRAM([#include  <stdatomic.h>], [])],
+[AC_COMPILE_IFELSE([AC_LANG_PROGRAM([#include  <stdatomic.h>], [_Atomic int foo;])],
                    [ac_cv_c11_stdatomic=yes],
                    [ac_cv_c11_stdatomic=no])])
 if test $ac_cv_c11_stdatomic = yes; then


### PR DESCRIPTION
I found that the master build was broken on Edison because while icc 17.0.1 had stdatomic.h, it still didn't recognize _Atomic as a keyword. However, we were only checking for stdatomic.h before setting HAVE_C11_STDATOMIC.