### PR TITLE
Fix pthread_setconcurrency warning

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -164,6 +164,9 @@ fi
 CXXFLAGS="${_old_CXXFLAGS}"
 ### End C++11 features check
 
+# We require at least POSIX.1-2001 for the pthread_setconcurrency function
+AC_DEFINE(_XOPEN_SOURCE, 600, [Enable X/Open 6 features.])
+
 # Variable substitutions.
 AC_SUBST([ac_aux_dir])
 AC_SUBST([abs_top_srcdir])

--- a/inc/hclib_config.h.in
+++ b/inc/hclib_config.h.in
@@ -7,4 +7,7 @@
 /* Defined if C++11 std::is_trivially_copyable is supported. */
 #undef HAVE_CXX11_TRIVIAL_COPY_CHECK
 
+/* Enable X/Open 6 features. */
+#undef _XOPEN_SOURCE
+
 #endif  // HCLIB_CONFIG_H_

--- a/src/hclib-runtime.c
+++ b/src/hclib-runtime.c
@@ -14,10 +14,6 @@
  * limitations under the License.
  */
 
-#include <pthread.h>
-#include <sys/time.h>
-#include <stddef.h>
-
 #include <hclib.h>
 #include <hclib-internal.h>
 #include <hclib-atomics.h>
@@ -25,6 +21,12 @@
 #include <hclib-hpt.h>
 #include <hcupc-support.hpp>
 #include <hclib-cuda.h>
+
+// These includes must come AFTER hclib-internal.h
+// to ensure that the hclib_config.h settings are included.
+#include <pthread.h>
+#include <sys/time.h>
+#include <stddef.h>
 
 // #define VERBOSE
 


### PR DESCRIPTION
Ensure X/Open 6 features are enabled to avoid compiler
warnings about undeclared functions on Linux.