### PR TITLE
Fix C includes for C++ headers

### DIFF
--- a/inc/hclib.h
+++ b/inc/hclib.h
@@ -17,13 +17,13 @@
 #ifndef HCLIB_H_
 #define HCLIB_H_
 
-#include "hclib_common.h"
-#include "hclib-task.h"
-#include "hclib-promise.h"
-
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+#include "hclib_common.h"
+#include "hclib-task.h"
+#include "hclib-promise.h"
 
 /**
  * @file Interface to HCLIB


### PR DESCRIPTION
C headers should be included from inside the `extern "C"` block.