### PR TITLE
Fix memset/memcpy warnings in HPT code

### DIFF
--- a/src/hclib-hpt.c
+++ b/src/hclib-hpt.c
@@ -14,14 +14,15 @@
  * limitations under the License.
  */
 
+#include "hclib-hpt.h"
+#include "hclib-internal.h"
+#include "hclib-atomics.h"
+
+#include <string.h>
 #include <stdio.h>
 #include <libxml/parser.h>
 #include <libxml/tree.h>
 #include <unistd.h>
-
-#include "hclib-hpt.h"
-#include "hclib-internal.h"
-#include "hclib-atomics.h"
 
 // #define VERBOSE
 


### PR DESCRIPTION
Missing string.h