### PR TITLE
Restore fixed worker pool strategy

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -12,7 +12,7 @@ AUX_DIST = \
 library_includedir=$(includedir)
 
 library_include_HEADERS = inc/hclib-timer.h inc/hclib-rt.h inc/hclib.h \
-						  inc/hclib_config.h \
+						  inc/hclib_config.h inc/hclib-worker-config.h \
 						  inc/hclib-mak/hclib.mak inc/hclib-async.hpp src/inc/hclib-hpt.h \
 						  inc/hclib-forasync.hpp inc/hclib-promise.h inc/hclib-promise.hpp \
 						  src/inc/hclib-atomics.h inc/hclib-place.h \

--- a/inc/hclib-rt.h
+++ b/inc/hclib-rt.h
@@ -57,6 +57,12 @@ typedef struct hclib_worker_state {
 #define HCLIB_MACRO_CONCAT(x, y) _HCLIB_MACRO_CONCAT_IMPL(x, y)
 #define _HCLIB_MACRO_CONCAT_IMPL(x, y) x ## y
 
+#ifdef HCLIB_DEBUG
+#define HC_DEBUG_ENABLED 1
+#else
+#define HC_DEBUG_ENABLED 0
+#endif
+
 #ifdef HC_ASSERTION_CHECK
 #define HC_ASSERTION_CHECK_ENABLED 1
 #else

--- a/inc/hclib-worker-config.h
+++ b/inc/hclib-worker-config.h
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2017 Rice University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef HCLIB_WORKER_CONFIG_H_
+#define HCLIB_WORKER_CONFIG_H_
+
+#include <stdint.h>
+
+/*
+ * NOTE:
+ *
+ * This file is assumed to follow a strict format to allow easy parsing
+ * by the hclib-options script. A list of the most important assumptions
+ * is included below. See the script for exact details.
+ *
+ * - Lines starting with C++-style double-slash comments are assumed
+ *   to be part of a description of a worker configuration option.
+ *
+ * - Definitions with the prefix HCLIB_WORKER_STRATEGY_ are assumed
+ *   to be options for setting the worker context-management strategy.
+ *
+ * - Definitions with the prefix HCLIB_WORKER_OPTIONS_ are assumed
+ *   to be additional options for the selected worker strategy.
+ *
+ * - Values for both types of definitions are assumed to be int constants.
+ */
+
+
+/***************************************/
+/* runtime worker threading strategies */
+/***************************************/
+
+// Fixed pool of worker threads.
+#define HCLIB_WORKER_STRATEGY_FIXED    0x01
+
+// Spawn a new fiber for each blocked task,
+// and join a fiber when a blocked task is resumed.
+#define HCLIB_WORKER_STRATEGY_FIBERS   0x02
+
+// Spawn a new thread for each blocked task,
+// and join a thread when a blocked task is resumed.
+#define HCLIB_WORKER_STRATEGY_THREADS  0x03
+
+
+/************************************/
+/* runtime worker threading options */
+/************************************/
+
+// Allow a worker context to run any ready task on top of the current
+// execution stack when a task blocks to help with global progress.
+// This option only affects the fixed worker pool strategy.
+// MAY CAUSE DEADLOCKS!
+#define HCLIB_WORKER_OPTIONS_HELP_GLOBAL  0x01
+
+// Allow a worker context to run a ready task from the current
+// finish scope on top of the current execution stack when blocking
+// on an end-finish to help with that finish scope's progress.
+#define HCLIB_WORKER_OPTIONS_HELP_FINISH  0x02
+
+// Do not explicitly join worker threads;
+// i.e., pthreads are created with the attribute PTHREAD_CREATE_DETACHED.
+#define HCLIB_WORKER_OPTIONS_NO_JOIN      0x04
+
+
+/*******************************/
+/* set up strategy and options */
+/*******************************/
+
+#define HCLIB_DEFAULT_WORKER_STRATEGY HCLIB_WORKER_STRATEGY_FIBERS
+#define HCLIB_DEFAULT_WORKER_OPTIONS  HCLIB_WORKER_OPTIONS_HELP_FINISH
+
+#ifdef HCLIB_DEBUG
+/* dynamic choice of worker configuration supported for debugging */
+#define HCLIB_WORKER_STRATEGY hclib_worker_strategy()
+#define HCLIB_WORKER_OPTIONS  hclib_worker_options()
+#else
+/* static choice of worker configuration required for production */
+#ifdef HCLIB_SET_WORKER_STRATEGY
+#define HCLIB_WORKER_STRATEGY HCLIB_SET_WORKER_STRATEGY
+#define HCLIB_WORKER_OPTIONS  HCLIB_SET_WORKER_OPTIONS
+#else
+#define HCLIB_WORKER_STRATEGY HCLIB_DEFAULT_WORKER_STRATEGY
+#define HCLIB_WORKER_OPTIONS  HCLIB_DEFAULT_WORKER_OPTIONS
+#endif  /* HCLIB_SET_WORKER_STRATEGY */
+#endif  /* HCLIB_DEBUG */
+
+
+/**************************************/
+/* functions to get the configuration */
+/**************************************/
+
+int64_t hclib_worker_strategy();
+int64_t hclib_worker_options();
+
+#endif  /* HCLIB_WORKER_CONFIG_H_ */

--- a/inc/hclib_common.h
+++ b/inc/hclib_common.h
@@ -18,6 +18,7 @@
 #define HCLIB_COMMON_H_
 
 #include "hclib_config.h"
+#include "hclib-worker-config.h"
 
 /*
  * Default async arguments
@@ -39,8 +40,5 @@
 #define PHASER_TRANSMIT_ALL ((int) 0x1) 
 /** @brief No accumulator argument provided. */
 #define NO_ACCUM NULL
-
-#define HCLIB_LITECTX_STRATEGY 1
-// #define VERBOSE 1
 
 #endif

--- a/install.sh
+++ b/install.sh
@@ -60,9 +60,11 @@ if [ -z `command -v xml2-config` ]; then
 fi
 
 mkdir -p `dirname ${HCLIB_ENV_SETUP_SCRIPT}`
+cp ../scripts/hclib-options ${INSTALL_PREFIX}/bin/
 cat > "${HCLIB_ENV_SETUP_SCRIPT}" <<EOI
 # HClib environment setup
 export HCLIB_ROOT='${INSTALL_PREFIX}'
+export PATH="\${HCLIB_ROOT}/bin:\${PATH}"
 EOI
 
 cat <<EOI

--- a/scripts/hclib-options
+++ b/scripts/hclib-options
@@ -1,0 +1,129 @@
+#!/usr/bin/env python
+#
+# Copyright 2017 Rice University
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+import argparse, os, re, sys
+
+strategies_map = {}
+options_map = {}
+
+current_description = ""
+
+def parse_worker_strategy_config(header_file):
+
+    # Patterns
+    p_description = re.compile('^\s*//(.*)$')
+    p_strategy = re.compile('^\s*#define\s+HCLIB_WORKER_STRATEGY_(\w+)\s+(\w+)')
+    p_option = re.compile('^\s*#define\s+HCLIB_WORKER_OPTIONS_(\w+)\s+(\w+)')
+
+    # Helper functions
+    def add_to_desc(desc):
+        global current_description
+        current_description += desc
+    def consume_desc():
+        global current_description
+        desc = current_description.strip()
+        current_description = ""
+        return desc
+    def as_name(x):
+        return x.lower()
+    def as_opt(x):
+        return '--' + x.lower().replace('_', '-')
+    def add_to_map(mapping, match):
+        opt_info = {'name': as_name(match.group(1)),
+                    'flag': as_opt(match.group(1)),
+                    'value': int(match.group(2), 0),
+                    'desc': consume_desc()}
+        mapping[opt_info['flag']] = opt_info
+
+    # Parse
+    for line in header_file:
+        # Description
+        match = p_description.match(line)
+        if match is not None:
+            add_to_desc(match.group(1))
+            continue
+        # Strategy
+        match = p_strategy.match(line)
+        if match is not None:
+            add_to_map(strategies_map, match)
+            continue
+        # Option
+        match = p_option.match(line)
+        if match is not None:
+            add_to_map(options_map, match)
+            continue
+
+# Try searching the current directory as the source root
+header_paths = ["./inc/hclib-worker-config.h"]
+
+# Also try searching HClib install root
+hclib_root = os.getenv('HCLIB_ROOT')
+if hclib_root is not None:
+    header_paths.append(hclib_root + "/include/hclib-worker-config.h")
+
+# Locate the header file
+for header_path in header_paths:
+    try:
+        with open(header_path) as f:
+            parse_worker_strategy_config(f)
+    except IOError: pass
+    else: break # found it!
+else: # didn't find the header file
+    sys.exit("Could not read \"{}\". Make sure HCLIB_ROOT is set correctly."
+             .format(header_path))
+
+worker_ctx_strategy = None
+worker_ctx_options  = 0x0
+
+class MapperAction(argparse.Action):
+    def __init__(self, option_strings, dest, info, **kwargs):
+        kwargs['nargs'] = 0
+        kwargs['help'] = info['desc']
+        super(MapperAction, self).__init__(option_strings, dest, **kwargs)
+
+class SetStrategy(MapperAction):
+    def __call__(self, parser, namespace, values, option_string=None):
+        global worker_ctx_strategy
+        worker_ctx_strategy = strategies_map[option_string]['value']
+
+class AddOption(MapperAction):
+    def __call__(self, parser, namespace, values, option_string=None):
+        global worker_ctx_options
+        worker_ctx_options |= options_map[option_string]['value']
+
+program_description = """Set HClib worker context options.
+
+Sample usage:
+
+    env $({} --threads --help-finish) ./your-hclib-app
+""".format(os.path.basename(__file__))
+
+parser = argparse.ArgumentParser(
+        description=program_description,
+        formatter_class=argparse.RawDescriptionHelpFormatter)
+
+strategy_group = parser.add_mutually_exclusive_group(required=True)
+for strategy, info in strategies_map.iteritems():
+    strategy_group.add_argument(strategy, info=info, action=SetStrategy)
+
+for option, info in options_map.iteritems():
+    parser.add_argument(option, info=info, action=AddOption)
+
+parser.parse_args()
+
+print("HCLIB_SET_WORKER_STRATEGY={:#x} HCLIB_SET_WORKER_OPTIONS={:#x}"
+      .format(worker_ctx_strategy, worker_ctx_options))

--- a/src/inc/hclib-finish.h
+++ b/src/inc/hclib-finish.h
@@ -23,9 +23,7 @@
 typedef struct finish_t {
     struct finish_t* parent;
     _Atomic int counter;
-#if HCLIB_LITECTX_STRATEGY
     hclib_future_t ** finish_deps;
-#endif /* HCLIB_LITECTX_STRATEGY */
 } finish_t;
 
 #endif

--- a/src/inc/hclib-internal.h
+++ b/src/inc/hclib-internal.h
@@ -20,6 +20,7 @@
 #include <stdarg.h>
 #include <stdint.h>
 #include "hclib_config.h"
+#include "hclib-worker-config.h"
 #include "hclib-tree.h"
 #include "hclib-deque.h"
 #include "hclib.h"


### PR DESCRIPTION
This patch re-enables the option of using the original worker strategy with a fixed pool of thread contexts (no fibers). This option can be useful for debugging, performance profiling, and as a way to avoid overheads introduced by fibers when an application uses a compatible subset of the API.

Note that the different strategies now use C conditionals rather than preprocessor conditionals to select the strategy. This allows us to support either run-time selection (for debugging) or compile-time selection (for production) of different thread strategies. I think removing most of the preprocessor `#if`s has also made the code more readable and maintainable. When the strategy is selected statically, the compiler should remove all of the dead branches for the unused strategies, with a result very similar to the version using preprocessor conditionals.

A simple python script is included to make it easier to select a desired set of worker context options when building the runtime (if set statically for production mode) or when launching a program (if set dynamically for debug mode). There are a few placeholders for the `HCLIB_WORKER_STRATEGY_THREADS` strategy, which will be added in a follow-on patch. Another follow-on patch will update our Travis configuration to run our regression tests against a matrix of worker-context configurations.