### PR TITLE
Modify MPI examples to work with new APIs

### DIFF
--- a/modules/mpi/test/init.cpp
+++ b/modules/mpi/test/init.cpp
@@ -1,13 +1,14 @@
 #include "hclib_cpp.h"
 #include "hclib_mpi.h"
-#include "hclib_system.h"
 
 #include <iostream>
 
 int main(int argc, char **argv) {
-    hclib::launch([] {
-        hclib::locale_t *rank = hclib::MPI_Comm_rank(MPI_COMM_WORLD);
-        std::cout << "Hello world from rank " << hclib::integer_rank_for_locale(rank) << std::endl;
+    const char *deps[] = { "system" };
+    hclib::launch(deps, 1, [] () {
+        int rank;
+        hclib::MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+        std::cout << "Hello world from rank " << rank << std::endl;
     });
     return 0;
 }

--- a/modules/mpi/test/isend_irecv.cpp
+++ b/modules/mpi/test/isend_irecv.cpp
@@ -1,14 +1,14 @@
 #include "hclib_cpp.h"
 #include "hclib_mpi.h"
-#include "hclib_system.h"
 
 #include <assert.h>
 #include <iostream>
 
 int main(int argc, char **argv) {
-    hclib::launch([] {
-        hclib::locale_t *rank = hclib::MPI_Comm_rank(MPI_COMM_WORLD);
-        const int mpi_rank = hclib::integer_rank_for_locale(rank);
+    const char *deps[] = { "system" };
+    hclib::launch(deps, 1, [] () {
+        int mpi_rank;
+        hclib::MPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank);
 
         int nranks;
         MPI_Comm_size(MPI_COMM_WORLD, &nranks);
@@ -20,19 +20,17 @@ int main(int argc, char **argv) {
 
         assert(nranks % 2 == 0);
 
-        if (hclib::integer_rank_for_locale(rank) % 2 == 0) {
+        if (mpi_rank % 2 == 0) {
             std::cout << "Rank " << mpi_rank << " sending async msg to " <<
                 (mpi_rank + 1) << std::endl;
-            hclib::future_t *send_fut = hclib::MPI_Isend(&data, 1, MPI_INT,
-                hclib::MPI_Comm_remote(MPI_COMM_WORLD, mpi_rank + 1), 0,
-                MPI_COMM_WORLD);
+            hclib::future_t<void> *send_fut = hclib::MPI_Isend(&data, 1, MPI_INT,
+                mpi_rank + 1, 0, MPI_COMM_WORLD);
             send_fut->wait();
         } else {
             std::cout << "Rank " << mpi_rank << " receiving async msg from " <<
                 (mpi_rank - 1) << std::endl;
-            hclib::future_t *recv_fut = hclib::MPI_Irecv(&data, 1, MPI_INT,
-                hclib::MPI_Comm_remote(MPI_COMM_WORLD, mpi_rank - 1), 0,
-                MPI_COMM_WORLD);
+            hclib::future_t<void> *recv_fut = hclib::MPI_Irecv(&data, 1, MPI_INT,
+                mpi_rank - 1, 0, MPI_COMM_WORLD);
             recv_fut->wait();
             assert(data == mpi_rank - 1);
         }


### PR DESCRIPTION
The HClib MPI APIs were modified to use MPI ranks instead of locales. Reflecting those changes in the test examples.