### PR TITLE
Delete the redundant future wait_and_get APIs

### DIFF
--- a/inc/hclib-promise.h
+++ b/inc/hclib-promise.h
@@ -150,8 +150,6 @@ void hclib_promise_put(hclib_promise_t *promise, void *datum);
  */
 void *hclib_future_wait(hclib_future_t *future);
 
-void *hclib_future_wait_and_get(hclib_future_t *future);
-
 /*
  * Check if a value has been put on the corresponding promise.
  */

--- a/inc/hclib_future.h
+++ b/inc/hclib_future.h
@@ -30,12 +30,6 @@ struct future_t: public hclib_future_t {
         return tmp.val;
     }
 
-    T wait_and_get() {
-        _ValUnion tmp;
-        tmp.vp = hclib_future_wait_and_get(this);
-        return tmp.val;
-    }
-
     bool test() {
         return hclib_future_is_satisfied(this);
     }
@@ -51,10 +45,6 @@ struct future_t<T*>: public hclib_future_t {
     T *wait() {
         return static_cast<T*>(hclib_future_wait(this));
     }
-
-    T *wait_and_get() {
-        return static_cast<T*>(hclib_future_wait_and_get(this));
-    }
 };
 
 // Specialized for references
@@ -66,10 +56,6 @@ struct future_t<T&>: public hclib_future_t {
 
     T &wait() {
         return *static_cast<T*>(hclib_future_wait(this));
-    }
-
-    T &wait_and_get() {
-        return *static_cast<T*>(hclib_future_wait_and_get(this));
     }
 };
 

--- a/modules/cuda/test/async_simd.cu
+++ b/modules/cuda/test/async_simd.cu
@@ -11,10 +11,10 @@ static void helper() {
     const int N = 256;
 
     hclib::future_t<void*> *allocation = hclib::allocate_at(N * sizeof(int), gpu_locale);
-    int *dArr = (int *)allocation->wait_and_get();
+    int *dArr = (int *)allocation->wait();
 
     allocation = hclib::allocate_at(N * sizeof(int), cpu_locale);
-    int *hArr = (int *)allocation->wait_and_get();
+    int *hArr = (int *)allocation->wait();
 
     hclib::future_t<void> *kernel_future = hclib::async_simd([=] __host__ __device__ (int id, int width) {
         dArr[id] = width;

--- a/src/hclib-promise.c
+++ b/src/hclib-promise.c
@@ -104,11 +104,6 @@ void *hclib_future_get(hclib_future_t *future) {
     return future->owner->datum;
 }
 
-void *hclib_future_wait_and_get(hclib_future_t *future) {
-    hclib_future_wait(future);
-    return hclib_future_get(future);
-}
-
 /**
  * @brief Destruct a promise.
  * @param[in] nb_promises                           Size of the promise array

--- a/test/cpp/promise/async_future_await_at.cpp
+++ b/test/cpp/promise/async_future_await_at.cpp
@@ -22,7 +22,7 @@ int main(int argc, char ** argv) {
                 [prom, locale]() -> int { return prom->get_future()->get() + 1; }, prom->get_future(), locale);
 
             prom->put(PUT_VALUE);
-            int result = fut->wait_and_get();
+            int result = fut->wait();
             assert(result == PUT_VALUE + 1);
         });
     });


### PR DESCRIPTION
Title pretty much says it. The future wait_and_get() is now redundant with wait() as wait() also returns the datum placed in the associated promise. Rather than have two APIs, this change simply deletes the wait_and_get API in the C and C++ APIs.