### PR TITLE
Fix compilation issue on OSX and remove modules/system folders from build

### DIFF
--- a/inc/hclib-mak/hclib.mak
+++ b/inc/hclib-mak/hclib.mak
@@ -7,17 +7,13 @@ HCLIB_CFLAGS=-I$(HCLIB_ROOT)/include
 HCLIB_CXXFLAGS=-std=c++11 $(HCLIB_CFLAGS)
 HCLIB_LDFLAGS=-L$(HCLIB_ROOT)/lib
 
-ifndef GET_LINK_FLAG
-	GET_LINK_FLAG = -Wl,$(1)
-endif
-
 UNAME_S := $(shell uname -s)
 ifneq ($(UNAME_S),Darwin)
     IS_MAC_OS = 0
     HCLIB_LDLIBS=-lhclib -lrt -ldl
 else
     IS_MAC_OS = 1
-    HCLIB_LDLIBS=-lhclib $(call GET_LINK_FLAG,-force_load)
+    HCLIB_LDLIBS=-lhclib
 endif
 
 ifdef TBB_MALLOC

--- a/modules/system/inc/hclib_system.post.mak
+++ b/modules/system/inc/hclib_system.post.mak
@@ -1,8 +1,5 @@
 # Post Makefile includes are the main part of a module's build system, allowing
 # it to add flags to the overall project compile and link flags.
-HCLIB_CFLAGS+=-I$(HCLIB_ROOT)/../modules/system/inc
-HCLIB_CXXFLAGS+=-I$(HCLIB_ROOT)/../modules/system/inc
-HCLIB_LDFLAGS+=-L$(HCLIB_ROOT)/../modules/system/lib
 HCLIB_LDLIBS+=-lhclib_system
 
 # ifeq ($(IS_MAC_OS),1)


### PR DESCRIPTION

-force_load option is used to load static library in OSX and it was used with JSMN. Since JSMN is not a static library anymore, no need to load it.

modules/system libraries and include files are copied to HCLIB_ROOT and therefore no need to add these extra paths in building HClib programs.