### PR TITLE
Fix issue #73: Deadlock when using finish and async_await

### DIFF
--- a/inc/hclib-async-struct.h
+++ b/inc/hclib-async-struct.h
@@ -47,6 +47,7 @@ extern "C" {
 #endif
 
 extern void spawn(hclib_task_t * task);
+extern void spawn_root(hclib_task_t * task);
 extern void spawn_await_at(hclib_task_t *task, hclib_future_t **futures,
         const int nfutures, hclib_locale_t *locale);
 extern void spawn_at(hclib_task_t *task, hclib_locale_t *locale);

--- a/inc/hclib-rt.h
+++ b/inc/hclib-rt.h
@@ -108,6 +108,11 @@ typedef struct _hclib_worker_state {
      * Information on currently executing task.
      */
     void *curr_task;
+    /* Indicate whether this work is initiating hclib_finalize */ 
+    int is_terminator;
+
+    /* This value is used to get ouf of the core_work_loop and find_and_run_task under the root finish */
+    int root_counter_val;
 } __attribute__ ((aligned (128))) hclib_worker_state;
 
 #define HCLIB_MACRO_CONCAT(x, y) _HCLIB_MACRO_CONCAT_IMPL(x, y)

--- a/inc/hclib_cpp.h
+++ b/inc/hclib_cpp.h
@@ -17,7 +17,7 @@ template <typename T>
 inline void launch(const char **deps, int ndeps, T &&lambda) {
     typedef typename std::remove_reference<T>::type U;
     hclib_task_t *user_task = _allocate_async(new U(lambda));
-    hclib_launch((generic_frame_ptr)spawn, user_task, deps, ndeps);
+    hclib_launch((generic_frame_ptr)spawn_root, user_task, deps, ndeps);
 }
 
 template <typename T>
@@ -30,7 +30,7 @@ inline void launch(const int nworkers, const char **deps, int ndeps,
     sprintf(nworkers_str, "%d", nworkers);
     setenv("HCLIB_WORKERS", nworkers_str, 1);
 
-    hclib_launch((generic_frame_ptr)spawn, user_task, deps, ndeps);
+    hclib_launch((generic_frame_ptr)spawn_root, user_task, deps, ndeps);
 }
 
 extern hclib_worker_state *current_ws();

--- a/src/inc/hclib-internal.h
+++ b/src/inc/hclib-internal.h
@@ -98,6 +98,8 @@ typedef struct hclib_context {
     /* a simple implementation of wait/wakeup condition */
     volatile int workers_wait_cond;
     worker_done_t *done_flags;
+    /* flag to indicate whether the root task is completed */
+    int root_done_flag;
 #ifdef HC_CUDA
     hclib_memory_tree_node *pinned_host_allocs;
     cudaStream_t stream;

--- a/test/cpp/Makefile
+++ b/test/cpp/Makefile
@@ -8,7 +8,7 @@ TARGETS=async0 async1 finish0 finish1 finish2  forasync1DCh  forasync1DRec \
 		promise/future1 promise/future2 promise/future3 promise/future4 neconlce1 access_argc \
 		promise/asyncAwait0Shared promise/asyncAwait0Unique \
 		promise/future0Float promise/future0Int \
-		no_async_finish nested_finish future_wait_in_finish atomic atomic_sum \
+		no_async_finish nested_finish nested_finish_async_await future_wait_in_finish atomic atomic_sum \
 		capture0 capture1 copies0 copies1 promise/async_future_await_at promise/asyncAwait0Vector
 
 FLAGS=-g -std=c++11 -Wall

--- a/test/cpp/nested_finish_async_await.cpp
+++ b/test/cpp/nested_finish_async_await.cpp
@@ -1,0 +1,36 @@
+#include "hclib_cpp.h"
+#include <iostream>
+int main (int argc, char *argv[])
+{
+  int n_rounds = 100, n_tiles=5;
+  const char *deps[] = { "system" };
+  hclib::launch(deps, 1, [&]() {
+      //create a 2D array of promises
+      auto tile_array = new hclib::promise_t<void*>**[n_rounds+1];
+      for (int tt=0; tt < n_rounds+1; ++tt) {
+          tile_array[tt] = new hclib::promise_t<void*>*[n_tiles];
+          for (int j=0; j < n_tiles; ++j) {
+              tile_array[tt][j] = new hclib::promise_t<void*>();
+          }
+      }
+      for (int j=0; j < n_tiles; ++j)
+          tile_array[0][j]->put(nullptr);
+      
+      for (int tt=0; tt < n_rounds; ++tt){
+          for (int j=0; j<n_tiles; ++j) {
+              int left_nbr = (n_tiles+j-1)%n_tiles;
+              int right_nbr = (j+1)%n_tiles;
+              hclib::async_await([=]{
+                  hclib::finish([=]{
+                      hclib::async_await([=]{
+                          tile_array[tt+1][j]->put(nullptr);                       
+                      }, tile_array[tt][left_nbr]->get_future());                                 
+                  });
+              }, tile_array[tt][left_nbr]->get_future(),
+              tile_array[tt][right_nbr]->get_future());
+          }
+          std::cout<<"finished "<< tt+1 <<" / "<<n_rounds<<std::endl;
+      }
+  });
+  return 0;
+}


### PR DESCRIPTION
This fixes the issue #73 considering that root finish can run in core_work_loop so all the workers cannot  get out of the loop by 'hclib_signal_join'