### PR TITLE
Hclib mem tie break

### DIFF
--- a/src/hclib-mem.c
+++ b/src/hclib-mem.c
@@ -191,9 +191,13 @@ hclib_future_t *hclib_async_copy(hclib_locale_t *dst_locale, void *dst,
         copy_cb = dst_cb;
     } else {
         // Not both MUST_USE
-        assert(!(dst_priority == MUST_USE && src_priority == MUST_USE));
-        if (src_priority == MUST_USE) copy_cb = src_cb;
-        else copy_cb = dst_cb;
+        if (dst_cb == src_cb) {
+            copy_cb = dst_cb;
+        } else {
+            assert(!(dst_priority == MUST_USE && src_priority == MUST_USE));
+            if (src_priority == MUST_USE) copy_cb = src_cb;
+            else copy_cb = dst_cb;
+        }
     }
 
     copy_struct *cs = (copy_struct *)malloc(sizeof(copy_struct));

--- a/src/hclib-mem.c
+++ b/src/hclib-mem.c
@@ -190,10 +190,10 @@ hclib_future_t *hclib_async_copy(hclib_locale_t *dst_locale, void *dst,
     } else if (src_cb == NULL) {
         copy_cb = dst_cb;
     } else {
-        // Not both MUST_USE
         if (dst_cb == src_cb) {
             copy_cb = dst_cb;
         } else {
+            // Must not both be MUST_USE
             assert(!(dst_priority == MUST_USE && src_priority == MUST_USE));
             if (src_priority == MUST_USE) copy_cb = src_cb;
             else copy_cb = dst_cb;


### PR DESCRIPTION
@srirajpaul one more small bug fix.

When copying between two HClib places/locales, the runtime needs to figure out what kind of copy API it has to use (e.g. memcpy, cudaMemcpy, etc). If it encounters a copy between two locales that each say HClib must use its copy API, HClib has no way of really negotiating between the two and will abort. This change handles the trivial case where the two places being copied between both say HClib must use their proprietary API, but those two places are both asking for the same API.