### PR TITLE
Add a std::vector<>* variant of async await, set CRAYPE_LINK_TYPE to install script to make building on Cray machines simpler

### DIFF
--- a/inc/hclib-async.h
+++ b/inc/hclib-async.h
@@ -232,6 +232,19 @@ inline void async_nb_await_at(T&& lambda, std::vector<hclib_future_t *> &&future
 }
 
 template <typename T>
+inline void async_nb_await_at(T&& lambda, std::vector<hclib_future_t *> *futures,
+        hclib_locale_t *locale) {
+    async_await_at_helper(lambda, futures ? futures->data() : nullptr,
+            futures ? futures->size() : 0, locale, 1);
+}
+
+template <typename T>
+inline void async_nb_await(T&& lambda, std::vector<hclib_future_t *> *futures) {
+    async_await_at_helper(lambda, futures ? futures->data() : nullptr,
+            futures ? futures->size() : 0, nullptr, 1);
+}
+
+template <typename T>
 inline void async_await(T&& lambda, hclib_future_t *future) {
 	MARK_OVH(current_ws()->id);
     typedef typename std::remove_reference<T>::type U;
@@ -284,6 +297,12 @@ inline void async_await(T&& lambda, std::vector<hclib_future_t *> &futures) {
 template <typename T>
 inline void async_await(T&& lambda, std::vector<hclib_future_t *> &&futures) {
     async_await_at_helper(lambda, futures.data(), futures.size(), nullptr, 0);
+}
+
+template <typename T>
+inline void async_await(T&& lambda, std::vector<hclib_future_t *> *futures) {
+    async_await_at_helper(lambda, futures ? futures->data() : NULL,
+            futures ? futures->size() : 0, nullptr, 0);
 }
 
 template <typename T>

--- a/install.sh
+++ b/install.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+export CRAYPE_LINK_TYPE=dynamic
+
 # Cmake, Make and Install
 
 #


### PR DESCRIPTION
@srirajpaul just a couple of small changes related to the herds project. Do you see any problem just setting CRAYPE_LINK_TYPE in the install script?